### PR TITLE
Smooth ramping of ATR and Torque Tilt

### DIFF
--- a/src/atr.h
+++ b/src/atr.h
@@ -25,6 +25,7 @@
 typedef struct {
     float on_step_size;
     float off_step_size;
+    float ramped_step_size;
 
     float accel_diff;
     float speed_boost;

--- a/src/torque_tilt.c
+++ b/src/torque_tilt.c
@@ -29,6 +29,7 @@ void torque_tilt_reset(TorqueTilt *tt) {
 void torque_tilt_configure(TorqueTilt *tt, const RefloatConfig *config) {
     tt->on_step_size = config->torquetilt_on_speed / config->hertz;
     tt->off_step_size = config->torquetilt_off_speed / config->hertz;
+    tt->ramped_step_size = 0;
 }
 
 void torque_tilt_update(TorqueTilt *tt, const MotorData *motor, const RefloatConfig *config) {
@@ -60,7 +61,37 @@ void torque_tilt_update(TorqueTilt *tt, const MotorData *motor, const RefloatCon
         step_size /= 2;
     }
 
-    rate_limitf(&tt->offset, target_offset, step_size);
+    // Smoothen changes in tilt angle by ramping the step size
+    if (config->inputtilt_smoothing_factor > 0) {
+        float smoothing_factor = 0.04;
+        // Sets the angle away from Target that step size begins ramping down
+        float smooth_center_window = 1.5;
+        float tiltback_target_diff = target_offset - tt->offset;
+
+        // Within X degrees of Target Angle, start ramping down step size
+        if (fabsf(tiltback_target_diff) < smooth_center_window) {
+            // Target step size is reduced the closer to center you are (needed for smoothly
+            // transitioning away from center)
+            tt->ramped_step_size = (smoothing_factor * step_size * (tiltback_target_diff / 2)) +
+                ((1 - smoothing_factor) * tt->ramped_step_size);
+            // Linearly ramped down step size is provided as minimum to prevent overshoot
+            float centering_step_size =
+                fminf(fabsf(tt->ramped_step_size), fabsf(tiltback_target_diff / 2) * step_size) *
+                sign(tiltback_target_diff);
+            if (fabsf(tiltback_target_diff) < fabsf(centering_step_size)) {
+                tt->offset = target_offset;
+            } else {
+                tt->offset += centering_step_size;
+            }
+        } else {
+            // Ramp up step size until the configured tilt speed is reached
+            tt->ramped_step_size = (smoothing_factor * step_size * sign(tiltback_target_diff)) +
+                ((1 - smoothing_factor) * tt->ramped_step_size);
+            tt->offset += tt->ramped_step_size;
+        }
+    } else {
+        rate_limitf(&tt->offset, target_offset, step_size);
+    }
 }
 
 void torque_tilt_winddown(TorqueTilt *tt) {

--- a/src/torque_tilt.h
+++ b/src/torque_tilt.h
@@ -24,6 +24,7 @@
 typedef struct {
     float on_step_size;
     float off_step_size;
+    float ramped_step_size;
 
     float offset;  // rate-limited setpoint offset
 } TorqueTilt;

--- a/src/utils.c
+++ b/src/utils.c
@@ -33,6 +33,40 @@ void rate_limitf(float *value, float target, float step) {
     }
 }
 
+// Smoothen changes in tilt angle by ramping the step size
+// smooth_center_window: Sets the angle away from Target that step size begins ramping down
+void smooth_rampf(
+    float *value,
+    float *ramped_step,
+    float target,
+    float step,
+    float smoothing_factor,
+    float smooth_center_window
+) {
+    float tiltback_target_diff = target - *value;
+
+    // Within X degrees of Target Angle, start ramping down step size
+    if (fabsf(tiltback_target_diff) < smooth_center_window) {
+        // Target step size is reduced the closer to center you are (needed for smoothly
+        // transitioning away from center)
+        *ramped_step = (smoothing_factor * step * (tiltback_target_diff / 2)) +
+            ((1 - smoothing_factor) * *ramped_step);
+        // Linearly ramped down step size is provided as minimum to prevent overshoot
+        float centering_step = fminf(fabsf(*ramped_step), fabsf(tiltback_target_diff / 2) * step) *
+            sign(tiltback_target_diff);
+        if (fabsf(tiltback_target_diff) < fabsf(centering_step)) {
+            *value = target;
+        } else {
+            *value += centering_step;
+        }
+    } else {
+        // Ramp up step size until the configured tilt speed is reached
+        *ramped_step = (smoothing_factor * step * sign(tiltback_target_diff)) +
+            ((1 - smoothing_factor) * *ramped_step);
+        *value += *ramped_step;
+    }
+}
+
 float clampf(float value, float min, float max) {
     const float m = value < min ? min : value;
     return m > max ? max : m;

--- a/src/utils.h
+++ b/src/utils.h
@@ -97,3 +97,12 @@ float clampf(float value, float min, float max);
  * @param step A maximum unit of change of @p value.
  */
 void rate_limitf(float *value, float target, float step);
+
+void smooth_rampf(
+    float *value,
+    float *ramped_step_size,
+    float target,
+    float step,
+    float smoothing_factor,
+    float smooth_center_window
+);


### PR DESCRIPTION
This feature has been tested by a handful of riders for the past few months. 

Following the example of inputtilt where ramping rates of over 50deg/sec are used, 
we're doing the same for ATR and Torque Tilt now.

Setpoints are ramped slower when near the current setpoint. This allows for much higher
ramping speeds without causing a jerking effect.

Instead of using 5deg/sec and 3deg/sec one can now easily run 20 and 12
or even more without any perceived downsides.
