### PR TITLE
LEDs: add rainbow effects

### DIFF
--- a/src/conf/datatypes.h
+++ b/src/conf/datatypes.h
@@ -100,6 +100,9 @@ typedef enum {
     LED_ANIM_STROBE,
     LED_ANIM_KNIGHT_RIDER,
     LED_ANIM_FELONY,
+    LED_ANIM_RAINBOW_CYCLE,
+    LED_ANIM_RAINBOW_FADE,
+    LED_ANIM_RAINBOW_ROLL,
 } LedAnimMode;
 
 typedef enum {

--- a/src/conf/settings.xml
+++ b/src/conf/settings.xml
@@ -2433,6 +2433,9 @@ p, li { white-space: pre-wrap; }
             <enumNames>Strobe</enumNames>
             <enumNames>Knight Rider</enumNames>
             <enumNames>Felony</enumNames>
+            <enumNames>Rainbow Cycle</enumNames>
+            <enumNames>Rainbow Fade</enumNames>
+            <enumNames>Rainbow Roll</enumNames>
         </leds.front.mode>
         <leds.front.brightness>
             <longName>Front Brightness</longName>
@@ -2590,6 +2593,9 @@ p, li { white-space: pre-wrap; }
             <enumNames>Strobe</enumNames>
             <enumNames>Knight Rider</enumNames>
             <enumNames>Felony</enumNames>
+            <enumNames>Rainbow Cycle</enumNames>
+            <enumNames>Rainbow Fade</enumNames>
+            <enumNames>Rainbow Roll</enumNames>
         </leds.rear.mode>
         <leds.rear.brightness>
             <longName>Rear Brightness</longName>
@@ -2747,6 +2753,9 @@ p, li { white-space: pre-wrap; }
             <enumNames>Strobe</enumNames>
             <enumNames>Knight Rider</enumNames>
             <enumNames>Felony</enumNames>
+            <enumNames>Rainbow Cycle</enumNames>
+            <enumNames>Rainbow Fade</enumNames>
+            <enumNames>Rainbow Roll</enumNames>
         </leds.headlights.mode>
         <leds.headlights.brightness>
             <longName>Headlights Brightness</longName>
@@ -2906,6 +2915,9 @@ p, li { white-space: pre-wrap; }
             <enumNames>Strobe</enumNames>
             <enumNames>Knight Rider</enumNames>
             <enumNames>Felony</enumNames>
+            <enumNames>Rainbow Cycle</enumNames>
+            <enumNames>Rainbow Fade</enumNames>
+            <enumNames>Rainbow Roll</enumNames>
         </leds.taillights.mode>
         <leds.taillights.brightness>
             <longName>Taillights Brightness</longName>
@@ -3193,6 +3205,9 @@ p, li { white-space: pre-wrap; }
             <enumNames>Strobe</enumNames>
             <enumNames>Knight Rider</enumNames>
             <enumNames>Felony</enumNames>
+            <enumNames>Rainbow Cycle</enumNames>
+            <enumNames>Rainbow Fade</enumNames>
+            <enumNames>Rainbow Roll</enumNames>
         </leds.status_idle.mode>
         <leds.status_idle.brightness>
             <longName>Status Idle Brightness</longName>

--- a/src/leds.c
+++ b/src/leds.c
@@ -322,6 +322,32 @@ static void anim_felony(Leds *leds, const LedStrip *strip, const LedBar *bar, fl
     }
 }
 
+static void anim_rainbow_cycle(Leds *leds, const LedStrip *strip, float time) {
+    const uint8_t count = 10;
+    const float segment = 255.0f / count;
+    uint8_t color_idx = ((uint8_t) (time * count) % count) * segment;
+    strip_set_color(leds, strip, hue_to_color(color_idx), strip->brightness, 1.0f);
+}
+
+static void anim_rainbow_fade(Leds *leds, const LedStrip *strip, float time) {
+    uint8_t offset = fmodf(time, 1.0f) * 255.0f;
+    strip_set_color(leds, strip, hue_to_color(offset), strip->brightness, 1.0f);
+}
+
+static void anim_rainbow_roll(Leds *leds, const LedStrip *strip, float time) {
+    uint8_t offset = fmodf(time, 1.0f) * 255.0f;
+    for (int i = 0; i < strip->length; ++i) {
+        led_set_color(
+            leds,
+            strip,
+            i,
+            hue_to_color(255.0f / strip->length * i + offset),
+            strip->brightness,
+            1.0f
+        );
+    }
+}
+
 static void led_strip_animate(Leds *leds, const LedStrip *strip, const LedBar *bar, float time) {
     time *= bar->speed;
 
@@ -343,6 +369,15 @@ static void led_strip_animate(Leds *leds, const LedStrip *strip, const LedBar *b
         break;
     case LED_ANIM_FELONY:
         anim_felony(leds, strip, bar, time);
+        break;
+    case LED_ANIM_RAINBOW_CYCLE:
+        anim_rainbow_cycle(leds, strip, time);
+        break;
+    case LED_ANIM_RAINBOW_FADE:
+        anim_rainbow_fade(leds, strip, time);
+        break;
+    case LED_ANIM_RAINBOW_ROLL:
+        anim_rainbow_roll(leds, strip, time);
         break;
     }
 }


### PR DESCRIPTION
Setting the headlights to `Solid` with white, and then setting the taillights to `Rainbow Cycle` allows users to replicate the `Mullet` effect from the Float package.

Using `Rainbow Cycle` on the front and the back replicates the "Rave" effect from the Float package.

~~Rainbow Fade has also been added, which was inspired by the Float package's "RGB Fade" effect.~~
Renamed to `RGB Fade` after using `color_wheel`.