### PR TITLE
Use smooth duty universally

### DIFF
--- a/src/motor_data.c
+++ b/src/motor_data.c
@@ -24,8 +24,6 @@
 #include <math.h>
 
 void motor_data_reset(MotorData *m) {
-    m->duty_smooth = 0;
-
     m->acceleration = 0;
     m->accel_idx = 0;
     for (int i = 0; i < 40; i++) {
@@ -52,8 +50,7 @@ void motor_data_update(MotorData *m) {
     m->current = VESC_IF->mc_get_tot_current_directional_filtered();
     m->braking = m->abs_erpm > 250 && sign(m->current) != m->erpm_sign;
 
-    m->duty_cycle = fabsf(VESC_IF->mc_get_duty_cycle_now());
-    m->duty_smooth = m->duty_smooth * 0.9f + m->duty_cycle * 0.1f;
+    m->duty_cycle = m->duty_cycle * 0.9f + fabsf(VESC_IF->mc_get_duty_cycle_now()) * 0.1f;
 
     float current_acceleration = m->erpm - m->last_erpm;
     m->last_erpm = m->erpm;

--- a/src/motor_data.h
+++ b/src/motor_data.h
@@ -34,7 +34,6 @@ typedef struct {
     bool braking;
 
     float duty_cycle;
-    float duty_smooth;
 
     // an average calculated over last ACCEL_ARRAY_SIZE values
     float acceleration;


### PR DESCRIPTION
Duty cycle can spike a lot, the purposes it's used for can all benefit from the mild smoothing we already have. Unify the usage and only use smooth duty for everything.

@surfdado putting this into a PR so that you have a chance to comment, WDYT? The motivation is smoother duty for the haptic duty alert (I had some spikes trigger it during normal riding). Please add a review if you don't mind.

Untested at the time of posting the PR, I'll only merge after I test it, but it's basically just the duty pushback and the wheelslip detection that uses the duty value.