### PR TITLE
Flywheel safety: auto exit flywheel mode after 10s of being idle

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1443,6 +1443,10 @@ static void refloat_thd(void *arg) {
                 }
                 d->enable_upside_down = false;
                 d->state.darkride = false;
+                if (d->state.mode == MODE_FLYWHEEL) {
+                    // Same strategy for flywheel: exit mode after 10 seconds of idle
+                    flywheel_stop(d);
+                }
             }
             if (d->current_time - d->disengage_timer > 1800) {  // alert user after 30 minutes
                 if (d->current_time - d->nag_timer > 60) {  // beep every 60 seconds


### PR DESCRIPTION
Too many users have managed to ruin their package config by using flywheel mode and then not exiting the mode properly. This change uses the same strategy as we use for dark ride. Once it disengages the user has 10 seconds to put the board back into the upright/flywheel position, otherwise we return back to normal mode.