### PR TITLE
LEDs: Add support for the WRGB/RGBW color order (WS2814 LED chip)

### DIFF
--- a/src/conf/datatypes.h
+++ b/src/conf/datatypes.h
@@ -46,8 +46,9 @@ typedef enum {
 } LedPin;
 
 typedef enum {
-    LED_COLOR_GRB = 0,
-    LED_COLOR_RGB
+    LED_COLOR_GRBW = 0,
+    LED_COLOR_RGBW,
+    LED_COLOR_WRGB
 } LedColorOrder;
 
 typedef enum {

--- a/src/conf/settings.xml
+++ b/src/conf/settings.xml
@@ -3090,7 +3090,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;None: Disable LED controls&lt;/li&gt;&lt;/ul&gt;
 &lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;RGB: 3 channel LEDs (WS2811, WS2812b, WS2815, etc.)&lt;/li&gt;
-&lt;li style=&quot;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;RGBW: 4 channel LEDs with white channel (SK2812, SK6812, etc.)&lt;/li&gt;
+&lt;li style=&quot;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;RGBW: 4 channel LEDs with white channel (SK2812, SK6812, WS2814, etc.)&lt;/li&gt;
 &lt;li style=&quot;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;External Module: External LED control modules, such as the Floatwheel LCM&lt;/li&gt;&lt;/ul&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;External Module (LCM)&lt;/span&gt;&lt;/p&gt;
@@ -3152,14 +3152,17 @@ p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;LED strip color order:&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;GRB: WS2811, WS2812b, SK2812, SK6812&lt;/li&gt;&lt;/ul&gt;
-&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;RGB: WS2815&lt;/li&gt;&lt;/ul&gt;
+&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;GRB(W): WS2811, WS2812b, SK2812, SK6812&lt;/li&gt;&lt;/ul&gt;
+&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;RGB(W): WS2815&lt;/li&gt;&lt;/ul&gt;
+&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;(W)RGB: WS2814&lt;/li&gt;&lt;/ul&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Some strips have different color order, if your strip is not on the list, test which value works for you.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Some strips have different color order, if your strip is not on the list, test which value works for you.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If your LED Type is set to RGB, the White (W) byte placement will be ignored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
             <cDefine>CFG_DFLT_HARDWARE_LED_COLOR_ORDER</cDefine>
             <valInt>0</valInt>
-            <enumNames>GRB</enumNames>
-            <enumNames>RGB</enumNames>
+            <enumNames>GRB(W)</enumNames>
+            <enumNames>RGB(W)</enumNames>
+            <enumNames>(W)RGB</enumNames>
         </hardware.leds.color_order>
         <hardware.leds.status.count>
             <longName>Status LED Strip Length</longName>

--- a/src/led_driver.c
+++ b/src/led_driver.c
@@ -172,15 +172,20 @@ void led_driver_paint(LedDriver *driver, uint32_t *data, uint32_t length) {
         uint8_t g = cgamma((color >> 8) & 0xFF);
         uint8_t b = cgamma(color & 0xFF);
 
-        if (driver->color_order == LED_COLOR_GRB) {
+        if (driver->color_order == LED_COLOR_GRBW) {
             color = (g << 16) | (r << 8) | b;
         } else {
             color = (r << 16) | (g << 8) | b;
         }
 
         if (driver->bit_nr == 32) {
-            color <<= 8;
-            color |= w;
+            // White LED byte placement
+            if (driver->color_order == LED_COLOR_WRGB) {
+                color |= (w << 24);
+            } else {
+                color <<= 8;
+                color |= w;
+            }
         }
 
         for (int8_t bit = driver->bit_nr - 1; bit >= 0; --bit) {


### PR DESCRIPTION
This adds LED Color Order options with support for the WRGB/RGBW order. Updated docstrings accordingly.

Feature: Add new LED Color Order configs
- Add LED Color Order options with support for the WRGB order (WS2814 LED chip).
