### PR TITLE
Add Support for BMS Tiltback

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -8,6 +8,17 @@
 ; Set firmware version:
 (apply ext-set-fw-version (sysinfo 'fw-ver))
 
+(def version_major (first (sysinfo 'fw-ver)))
+(def version_minor (second (sysinfo 'fw-ver)))
+(if (or (eq (first (trap (get-bms-val 'bms-v-cell-min))) 'exit-ok) (or (>= version_major 7) (and (>= version_major 6) (>= version_minor 5)))) {
+    (loopwhile (and (< (get-bms-val 'bms-can-id) 0) (< (secs-since 0) 10.0)) (yield 1000000))
+    (if (>= (get-bms-val 'bms-can-id) 0) {
+        (import "src/bms.lisp" 'bms)
+        (read-eval-program bms)
+        (spawn bms-loop)
+    })
+})
+
 ; Set to 1 to monitor debug variables
 (define debug 1)
 

--- a/src/bms.c
+++ b/src/bms.c
@@ -1,0 +1,25 @@
+// Copyright 2024 Syler Clayton
+//
+// This file is part of the Refloat VESC package.
+//
+// Refloat VESC package is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Refloat VESC package is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <http://www.gnu.org/licenses/>.
+
+#include "bms.h"
+
+bool bms_is_fault_set(uint32_t fault_mask, BMSFaultCode fault_code) {
+    if (fault_code < 1 || fault_code > 32) {
+        return false;
+    }
+    return (fault_mask & (1U << (fault_code - 1))) != 0;
+}

--- a/src/bms.h
+++ b/src/bms.h
@@ -1,0 +1,34 @@
+// Copyright 2024 Syler Clayton
+//
+// This file is part of the Refloat VESC package.
+//
+// Refloat VESC package is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Refloat VESC package is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef enum {
+    BMSF_NONE = 0,
+    BMSF_CONNECTION = 1,
+    BMSF_OVER_TEMP = 2,
+    BMSF_CELL_OVER_VOLTAGE = 3,
+    BMSF_CELL_UNDER_VOLTAGE = 4,
+    BMSF_CELL_OVER_TEMP = 5,
+    BMSF_CELL_UNDER_TEMP = 6,
+    BMSF_CELL_BALANCE = 7
+} BMSFaultCode;
+
+bool bms_is_fault_set(uint32_t fault_mask, BMSFaultCode fault_code);

--- a/src/bms.lisp
+++ b/src/bms.lisp
@@ -1,0 +1,93 @@
+(defun bms-loop () {
+    (var vmin-limit)
+    (var vmax-limit)
+    (var tmax-limit)
+    (var tmin-limit -10)
+    (var cell-balance 0.5)
+    (var mosfet-tmax-limit)
+    (var config-update-time)
+    (var fault 0u32)
+    (var v-cell-support (eq (first (trap (get-bms-val 'bms-v-cell-min))) 'exit-ok))
+    (var bms-data-version-support (and (eq (first (trap (get-bms-val 'bms-data-version))) 'exit-ok) (> (get-bms-val 'bms-data-version) 0)))
+    (defun update-config () {
+        (setq vmin-limit (conf-get 'bms-vmin-limit-start))
+        (setq vmax-limit (conf-get 'bms-vmax-limit-start))
+        (setq tmax-limit (- (conf-get 'bms-t-limit-start) 3)) ; Start 3 degrees before Motor CFG -> BMS limiting functionality would happen.
+        (setq mosfet-tmax-limit (+ tmax-limit 15)) ; Set bms temp limit to +15C past cell limit
+        (setq config-update-time (systime))
+    })
+    (var fault-codes '(
+        (BMSF_NONE . 0)
+        (BMSF_CONNECTION . 1)
+        (BMSF_OVER_TEMP . 2)
+        (BMSF_CELL_OVER_VOLTAGE . 3)
+        (BMSF_CELL_UNDER_VOLTAGE . 4)
+        (BMSF_CELL_OVER_TEMP . 5)
+        (BMSF_CELL_UNDER_TEMP . 6)
+        (BMSF_CELL_BALANCE . 7)
+    ))
+    (defun set-fault (fault-code) {
+        (if (eq fault-code 'BMSF_NONE) {
+            (setq fault 0u32)
+        }{
+            (setq fault (bitwise-or fault (shl 1 (- (assoc fault-codes fault-code) 1))))
+        })
+    })
+    (update-config)
+    (loopwhile t {
+        (if (> (secs-since config-update-time) 1.0) {
+            (update-config)
+        })
+        (if (or (= vmin-limit 0.0) (= vmax-limit 0.0) (= tmax-limit 0.0)) {
+            (set-fault 'BMSF_NONE)
+        } {
+            (if (>= (get-bms-val 'bms-msg-age) 2.0) {
+                (set-fault 'BMSF_CONNECTION)
+            } {
+                (set-fault 'BMSF_NONE)
+
+                (var v-cell-min)
+                (var v-cell-max)
+                (if v-cell-support {
+                    (setq v-cell-min (get-bms-val 'bms-v-cell-min))
+                    (setq v-cell-max (get-bms-val 'bms-v-cell-max))
+                } {
+                    (var num-cells (get-bms-val 'bms-cell-num))
+                    (if (> num-cells 1) {
+                        (setq v-cell-max (get-bms-val 'bms-v-cell 0))
+                        (setq v-cell-min (get-bms-val 'bms-v-cell 0))
+                        (looprange i 1 num-cells {
+                            (var cell-volt (get-bms-val 'bms-v-cell i))
+                            (if (> cell-volt v-cell-max)
+                                (setq v-cell-max cell-volt))
+                            (if (< cell-volt v-cell-min)
+                                (setq v-cell-min cell-volt))
+                        })
+                    })
+                })
+
+                (var t-cell-min)
+                (var t-cell-max)
+                (if bms-data-version-support {
+                    (setq t-cell-min (get-bms-val 'bms-temps-adc 1))
+                    (setq t-cell-max (get-bms-val 'bms-temps-adc 2))
+                    (var t-mosfet-temp (get-bms-val 'bms-temps-adc 3))
+                    (if (> t-mosfet-temp -280) {
+                        (if (>= t-mosfet-temp mosfet-tmax-limit) (set-fault 'BMSF_OVER_TEMP))
+                    })
+                } {
+                    (setq t-cell-min (get-bms-val 'bms-temp-cell-max))
+                    (setq t-cell-max t-cell-min)
+                })
+
+                (if (>= v-cell-max vmax-limit) (set-fault 'BMSF_CELL_OVER_VOLTAGE))
+                (if (<= v-cell-min vmin-limit) (set-fault 'BMSF_CELL_UNDER_VOLTAGE))
+                (if (>= t-cell-max tmax-limit) (set-fault 'BMSF_CELL_OVER_TEMP))
+                (if (<= t-cell-min tmin-limit) (set-fault 'BMSF_CELL_UNDER_TEMP))
+                (if (>= (abs (- v-cell-max v-cell-min)) cell-balance) (set-fault 'BMSF_CELL_BALANCE))
+            })
+        })
+        (ext-bms-set-fault fault)
+        (yield 200000)
+    })
+})

--- a/ui.qml.in
+++ b/ui.qml.in
@@ -867,6 +867,13 @@ Item {
             [8, "Low Battery"],
             [9, "Board Idle"],
             [10, "Other"],
+            [11, "BMS: Cell Under Temp"],
+            [12, "BMS: Cell Over Temp"],
+            [13, "BMS: Cell Low Voltage"],
+            [14, "BMS: Cell High Voltage"],
+            [15, "BMS: Cell Balance"],
+            [16, "BMS: Connection Lost"],
+            [17, "BMS: BMS Temp"],
         ])
 
         property int beepReason: 0


### PR DESCRIPTION
```
    (var bms-fault-codes '(
        (NONE . 0)
        (BMS_COMM_TIMEOUT . 1) < 2 SECONDS. Not currently used in Refloat. Not sure where to put to notify user.
        (BMS_OVER_TEMP . 2) CELL_OVER_TEMP +10
        (CELL_OVER_VOLTAGE . 3)  bms-vmax-limit-start
        (CELL_UNDER_VOLTAGE . 4) bms-vmin-limit-start
        (CELL_OVER_TEMP . 5) bms-t-limit-start
        (CELL_UNDER_TEMP . 6) ; Not used
        (CELL_BALANCE . 7) <= 0.5v difference. Not currently used in Refloat. Not sure how to alert user.
    ))

The other values are from conf-get function in lisp. They can be found in Motor Config -> BMS. While we want the limit boxes unchecked, we can use these fields to customize limits for our own use. Note: I also check if any limits are enabled and disable them (since we want to do that with pushback not limiting motor current).
'bms-t-limit-start      ; Temperature where current starts to get reduced
'bms-vmin-limit-start   ; VCell where current starts to get reduced
'bms-vmax-limit-start   ; VCell where regen current starts to get reduced
```

Now package.lisp spawns a new process bms-state-loop which handles looking at user config values and BMS data to determine BMS state. It will search for a bms-can-id within first 10 seconds of boot and load the bms-state library if found. BMS faults are stored in an u32 as bitfields. They are sent to the main Refloat C loop with ext-bms-set-fault. In the areas that handle pushback bitfield checks with bool bms_is_fault_set(uint32_t fault_mask, BMS_FAULT_CODES fault_code) are now performed. Minimal code was touched in Refloat itself besides the additional checks, and BeepReason was expanded to handle additional error states.