### PR TITLE
Tweak Wheelslip timer exit to be more strict

### DIFF
--- a/src/motor_data.c
+++ b/src/motor_data.c
@@ -25,6 +25,7 @@
 
 void motor_data_reset(MotorData *m) {
     m->abs_erpm_smooth = 0;
+    m->duty_raw = 0;
 
     m->acceleration = 0;
     m->accel_idx = 0;
@@ -59,7 +60,8 @@ void motor_data_update(MotorData *m) {
     m->current = VESC_IF->mc_get_tot_current_directional_filtered();
     m->braking = m->abs_erpm > 250 && sign(m->current) != m->erpm_sign;
 
-    m->duty_cycle += 0.01f * (fabsf(VESC_IF->mc_get_duty_cycle_now()) - m->duty_cycle);
+    m->duty_raw = fabsf(VESC_IF->mc_get_duty_cycle_now());
+    m->duty_cycle += 0.01f * (m->duty_raw - m->duty_cycle);
 
     float current_acceleration = m->erpm - m->last_erpm;
     m->last_erpm = m->erpm;

--- a/src/motor_data.h
+++ b/src/motor_data.h
@@ -35,6 +35,7 @@ typedef struct {
     bool braking;
 
     float duty_cycle;
+    float duty_raw;
 
     // an average calculated over last ACCEL_ARRAY_SIZE values
     float acceleration;


### PR DESCRIPTION
- Made Wheelslip timer reset condition and exit condition more strict, as to decrease the likelihood of lingering false positives (which prevent alerts like haptic buzz)
- This should preferably be reverted in the future, with instead a sufficient *additional* exit condition option, such as looking at power, or speed delta prior to wheelslip
- Also added duty_raw