### PR TITLE
Parking mode idle improved behavior

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -559,6 +559,8 @@ static bool check_faults(data *d) {
             // allow turning it off by engaging foot sensors
             state_stop(&d->state, STOP_SWITCH_HALF);
             return true;
+        } else {
+            d->motor.last_erpm_sign = d->motor.erpm_sign;
         }
     } else {
         bool disable_switch_faults = d->float_conf.fault_moving_fault_disabled &&
@@ -592,6 +594,7 @@ static bool check_faults(data *d) {
             }
         } else {
             d->fault_switch_timer = d->current_time;
+            d->motor.last_erpm_sign = d->motor.erpm_sign;
         }
 
         // Feature: Reverse-Stop
@@ -1453,9 +1456,7 @@ static void refloat_thd(void *arg) {
             break;
         }
 
-        motor_control_apply(
-            &d->motor_control, d->motor.abs_erpm_smooth, d->state.state, d->current_time
-        );
+        motor_control_apply(&d->motor_control, &d->motor, d->state.state, d->current_time);
         VESC_IF->sleep_us(d->loop_time_us);
     }
 }

--- a/src/motor_control.h
+++ b/src/motor_control.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 #include "conf/datatypes.h"
+#include "motor_data.h"
 #include "state.h"
 
 typedef struct {
@@ -48,7 +49,7 @@ void motor_control_configure(MotorControl *mc, const RefloatConfig *config);
 
 void motor_control_request_current(MotorControl *mc, float current);
 
-void motor_control_apply(MotorControl *mc, float abs_erpm, RunState state, float time);
+void motor_control_apply(MotorControl *mc, const MotorData *md, RunState state, float time);
 
 void motor_control_play_tone(MotorControl *mc, uint16_t frequency, float intensity);
 

--- a/src/motor_data.h
+++ b/src/motor_data.h
@@ -30,6 +30,7 @@ typedef struct {
     float abs_erpm_smooth;
     float last_erpm;
     int8_t erpm_sign;
+    int8_t last_erpm_sign;  // last erpm sign prior to footpads disengaging
 
     float current;
     bool braking;


### PR DESCRIPTION
If rider jumps off the board and the board changes direction after jumping off, it is assumed that the parking brake should be on.

This addresses the use case where you're going uphill and you jump off because it got too steep