### PR TITLE
Feature: Add Support for BMS Tiltback 2.0

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -8,6 +8,13 @@
 ; Set firmware version:
 (apply ext-set-fw-version (sysinfo 'fw-ver))
 
+; Init bms
+(if (>= (first (sysinfo 'fw-ver)) 6) {
+    (import "src/bms.lisp" 'bms)
+    (read-eval-program bms)
+    (spawn "bms" 50 init-bms)
+})
+
 ; Set to 1 to monitor debug variables
 (define debug 1)
 

--- a/src/bms.c
+++ b/src/bms.c
@@ -1,0 +1,31 @@
+// Copyright 2024 Syler Clayton
+//
+// This file is part of the Refloat VESC package.
+//
+// Refloat VESC package is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Refloat VESC package is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <http://www.gnu.org/licenses/>.
+
+#include "bms.h"
+
+bool bms_get_fault(uint32_t fault_mask, BMSFaultCode fault_code) {
+    return (fault_mask & (1U << (fault_code - 1))) != 0;
+}
+
+void bms_set_fault(uint32_t *fault_mask, BMSFaultCode fault_code) {
+    if (fault_code == BMSF_NONE) {
+        *fault_mask = BMSF_NONE;
+        return;
+    }
+
+    *fault_mask |= (1U << (fault_code - 1));
+}

--- a/src/bms.h
+++ b/src/bms.h
@@ -1,0 +1,36 @@
+// Copyright 2024 Syler Clayton
+//
+// This file is part of the Refloat VESC package.
+//
+// Refloat VESC package is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Refloat VESC package is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef enum {
+    BMSF_NONE = 0,
+    BMSF_CONNECTION = 1,
+    BMSF_OVER_TEMP = 2,
+    BMSF_CELL_OVER_VOLTAGE = 3,
+    BMSF_CELL_UNDER_VOLTAGE = 4,
+    BMSF_CELL_OVER_TEMP = 5,
+    BMSF_CELL_UNDER_TEMP = 6,
+    BMSF_CELL_BALANCE = 7
+} BMSFaultCode;
+
+bool bms_get_fault(uint32_t fault_mask, BMSFaultCode fault_code);
+
+void bms_set_fault(uint32_t *fault_mask, BMSFaultCode fault_code);

--- a/src/bms.lisp
+++ b/src/bms.lisp
@@ -1,0 +1,39 @@
+
+(defun init-bms () {
+    (var v-cell-support (eq (first (trap (get-bms-val 'bms-v-cell-min))) 'exit-ok))
+    (var temp-max 0)
+    (var temp-min 0)
+    (var v-min 0)
+    (var v-max 0)
+    (var temp-fet -281)
+    (var num-cells 0)
+    (var cell-v 0.0)
+    (loopwhile t {
+        (if (and (>= (get-bms-val 'bms-can-id) 0) (ext-bms)) {
+            (setq temp-max (get-bms-val 'bms-temp-cell-max))
+            (setq temp-min temp-max)
+            
+            (if v-cell-support {
+                (if (= (get-bms-val 'bms-data-version) 1) {
+                    (setq temp-min (get-bms-val 'bms-temps-adc 1))
+                    (setq temp-fet (get-bms-val 'bms-temps-adc 3))
+                })
+                (setq v-min (get-bms-val 'bms-v-cell-min))
+                (setq v-max (get-bms-val 'bms-v-cell-max))
+            } {
+                (setq num-cells (get-bms-val 'bms-cell-num))
+                (if (> num-cells 0) {
+                    (setq v-min (get-bms-val 'bms-v-cell 0))
+                    (setq v-max v-min)
+                    (looprange i 1 num-cells {
+                        (setq cell-v (get-bms-val 'bms-v-cell i))
+                        (if (< cell-v v-min) (setq v-min cell-v))
+                        (if (> cell-v v-max) (setq v-max cell-v))
+                    })
+                })
+            })
+            (ext-bms v-min v-max temp-min temp-max temp-fet (get-bms-val 'bms-msg-age))
+        })
+        (sleep 0.2)
+    })
+})

--- a/src/conf/datatypes.h
+++ b/src/conf/datatypes.h
@@ -193,6 +193,14 @@ typedef struct {
     float tiltback_variable;
     float tiltback_variable_max;
     uint16_t tiltback_variable_erpm;
+    bool tiltback_bms_enabled;
+    float tiltback_cell_lv;
+    float tiltback_cell_hv;
+    int8_t tiltback_cell_lt;
+    int8_t tiltback_cell_ht;
+    int8_t tiltback_bms_ht;
+    uint8_t tiltback_bms_msg;
+    float tiltback_cell_bal;
     FLOAT_INPUTTILT_REMOTE_TYPE inputtilt_remote_type;
     float inputtilt_speed;
     float inputtilt_angle_limit;

--- a/src/conf/settings.xml
+++ b/src/conf/settings.xml
@@ -859,6 +859,178 @@ p, li { white-space: pre-wrap; }
             <suffix> ERPM</suffix>
             <vTx>3</vTx>
         </tiltback_variable_erpm>
+        <tiltback_bms_enabled>
+            <longName>Enable BMS Tiltback</longName>
+            <type>5</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TILTBACK_BMS_ENABLED</cDefine>
+            <valInt>0</valInt>
+        </tiltback_bms_enabled>
+        <tiltback_cell_lv>
+            <longName>Cell Low Voltage Threshold</longName>
+            <type>1</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Low Voltage threshold per cell to trigger a safety pushback.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Recommended Value: 3.0V&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TILTBACK_CELL_LV</cDefine>
+            <editorDecimalsDouble>2</editorDecimalsDouble>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxDouble>4.3</maxDouble>
+            <minDouble>2.5</minDouble>
+            <showDisplay>0</showDisplay>
+            <stepDouble>0.01</stepDouble>
+            <valDouble>3</valDouble>
+            <vTxDoubleScale>1000</vTxDoubleScale>
+            <suffix> V</suffix>
+            <vTx>7</vTx>
+        </tiltback_cell_lv>
+        <tiltback_cell_hv>
+            <longName>Cell High Voltage Threshold</longName>
+            <type>1</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;High Voltage threshold per cell to trigger a safety pushback.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Recommended Value: 4.2V&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TILTBACK_CELL_HV</cDefine>
+            <editorDecimalsDouble>2</editorDecimalsDouble>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxDouble>4.3</maxDouble>
+            <minDouble>2.5</minDouble>
+            <showDisplay>0</showDisplay>
+            <stepDouble>0.01</stepDouble>
+            <valDouble>4.2</valDouble>
+            <vTxDoubleScale>1000</vTxDoubleScale>
+            <suffix> V</suffix>
+            <vTx>7</vTx>
+        </tiltback_cell_hv>
+        <tiltback_cell_lt>
+            <longName>Cell Low Temp Threshold</longName>
+            <type>2</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Low Temp threshold per cell to trigger a safety pushback.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Recommended Value: -10 C&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TILTBACK_CELL_LT</cDefine>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxInt>60</maxInt>
+            <minInt>-20</minInt>
+            <showDisplay>0</showDisplay>
+            <stepInt>1</stepInt>
+            <valInt>-5</valInt>
+            <suffix> C</suffix>
+            <vTx>2</vTx>
+        </tiltback_cell_lt>
+        <tiltback_cell_ht>
+            <longName>Cell High Temp Threshold</longName>
+            <type>2</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;High Temp threshold per cell to trigger a safety pushback.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Recommended Value: 45 C&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TILTBACK_CELL_HT</cDefine>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxInt>60</maxInt>
+            <minInt>-20</minInt>
+            <showDisplay>0</showDisplay>
+            <stepInt>1</stepInt>
+            <valInt>45</valInt>
+            <suffix> C</suffix>
+            <vTx>2</vTx>
+        </tiltback_cell_ht>
+        <tiltback_bms_ht>
+            <longName>BMS MOSFET High Temp Threshold</longName>
+            <type>2</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;High Temp threshold for BMS MOSFET to trigger a safety pushback (if bms-data-version = 1 in 6.06+).&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Recommended Value: 60 C&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TILTBACK_BMS_HT</cDefine>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxInt>70</maxInt>
+            <minInt>-20</minInt>
+            <showDisplay>0</showDisplay>
+            <stepInt>1</stepInt>
+            <valInt>60</valInt>
+            <suffix> C</suffix>
+            <vTx>2</vTx>
+        </tiltback_bms_ht>
+        <tiltback_bms_msg>
+            <longName>BMS Communication Threshold</longName>
+            <type>2</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;BMS Communication threshold to trigger a safety pushback.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Recommended Value: 2 sec&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TILTBACK_BMS_MSG</cDefine>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxInt>5</maxInt>
+            <minInt>1</minInt>
+            <showDisplay>0</showDisplay>
+            <stepInt>1</stepInt>
+            <valInt>2</valInt>
+            <suffix> sec</suffix>
+            <vTx>1</vTx>
+        </tiltback_bms_msg>
+        <tiltback_cell_bal>
+            <longName>Cell Balance Threshold</longName>
+            <type>1</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Cell Balance threshold to trigger a warning beep while idle.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Recommended Value: 0.5 V&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TILTBACK_CELL_BAL</cDefine>
+            <editorDecimalsDouble>2</editorDecimalsDouble>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxDouble>1</maxDouble>
+            <minDouble>0</minDouble>
+            <showDisplay>0</showDisplay>
+            <stepDouble>0.01</stepDouble>
+            <valDouble>0.3</valDouble>
+            <vTxDoubleScale>100</vTxDoubleScale>
+            <suffix> V</suffix>
+            <vTx>7</vTx>
+        </tiltback_cell_bal>
         <noseangling_speed>
             <longName>Nose Angling Speed</longName>
             <type>1</type>
@@ -3420,6 +3592,14 @@ p, li { white-space: pre-wrap; }
         <ser>hardware.leds.rear.reverse</ser>
         <ser>is_beeper_enabled</ser>
         <ser>disabled</ser>
+        <ser>tiltback_bms_enabled</ser>
+        <ser>tiltback_cell_lv</ser>
+        <ser>tiltback_cell_hv</ser>
+        <ser>tiltback_cell_lt</ser>
+        <ser>tiltback_cell_ht</ser>
+        <ser>tiltback_bms_msg</ser>
+        <ser>tiltback_cell_bal</ser>
+        <ser>tiltback_bms_ht</ser>
     </SerOrder>
     <Grouping>
         <group>
@@ -3553,6 +3733,15 @@ p, li { white-space: pre-wrap; }
                     <param>::sep::Low Voltage Alert Pushback</param>
                     <param>tiltback_lv_angle</param>
                     <param>tiltback_lv_speed</param>
+                    <param>::sep::BMS Pushback (6.0+)</param>
+                    <param>tiltback_bms_enabled</param>
+                    <param>tiltback_cell_lv</param>
+                    <param>tiltback_cell_hv</param>
+                    <param>tiltback_cell_lt</param>
+                    <param>tiltback_cell_ht</param>
+                    <param>tiltback_bms_ht</param>
+                    <param>tiltback_bms_msg</param>
+                    <param>tiltback_cell_bal</param>
                 </subgroupParams>
             </subgroup>
             <subgroup>

--- a/src/data.h
+++ b/src/data.h
@@ -130,6 +130,8 @@ typedef struct {
     float rc_current_target;
     float rc_current;
 
+    uint32_t bms_fault;
+
     Konami flywheel_konami;
     Konami headlights_on_konami;
     Konami headlights_off_konami;

--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,7 @@
 #include "vesc_c_if.h"
 
 #include "atr.h"
+#include "bms.h"
 #include "booster.h"
 #include "brake_tilt.h"
 #include "charging.h"
@@ -64,7 +65,14 @@ typedef enum {
     BEEP_SENSORS = 7,
     BEEP_LOWBATT = 8,
     BEEP_IDLE = 9,
-    BEEP_ERROR = 10
+    BEEP_ERROR = 10,
+    BEEP_TEMP_CELL_UNDER = 11,
+    BEEP_TEMP_CELL_OVER = 12,
+    BEEP_CELL_LV = 13,
+    BEEP_CELL_HV = 14,
+    BEEP_CELL_BALANCE = 15,
+    BEEP_BMS_CONNECTION = 16,
+    BEEP_BMS_TEMP_OVER = 17
 } BeepReason;
 
 static const FootpadSensorState flywheel_konami_sequence[] = {
@@ -226,6 +234,12 @@ static void configure(Data *d) {
         sizeof(headlights_off_konami_sequence)
     );
 
+    if (d->float_conf.tiltback_bms_enabled) {
+        d->bms_fault = BMSF_CONNECTION;
+    } else {
+        d->bms_fault = BMSF_NONE;
+    }
+
     reconfigure(d);
 
     if (d->state.state == STATE_DISABLED) {
@@ -330,6 +344,7 @@ static float get_setpoint_adjustment_step_size(Data *d) {
         return d->tiltback_duty_step_size;
     case (SAT_PB_HIGH_VOLTAGE):
     case (SAT_PB_TEMPERATURE):
+    case (SAT_PB_BMS_CONNECTION):
         return d->tiltback_hv_step_size;
     case (SAT_PB_LOW_VOLTAGE):
         return d->tiltback_lv_step_size;
@@ -522,7 +537,8 @@ static bool check_faults(Data *d) {
 }
 
 static void calculate_setpoint_target(Data *d) {
-    if (d->motor.batt_voltage < d->float_conf.tiltback_hv) {
+    if (d->motor.batt_voltage < d->float_conf.tiltback_hv &&
+        !bms_get_fault(d->bms_fault, BMSF_CELL_OVER_VOLTAGE)) {
         timer_refresh(&d->time, &d->tb_highvoltage_timer);
     }
 
@@ -595,11 +611,18 @@ static void calculate_setpoint_target(Data *d) {
         if (d->state.mode != MODE_FLYWHEEL) {
             d->state.sat = SAT_PB_DUTY;
         }
-    } else if (d->motor.duty_cycle > 0.05 && d->motor.batt_voltage > d->float_conf.tiltback_hv) {
-        d->beep_reason = BEEP_HV;
+    } else if (d->motor.duty_cycle > 0.05 &&
+               (d->motor.batt_voltage > d->float_conf.tiltback_hv ||
+                bms_get_fault(d->bms_fault, BMSF_CELL_OVER_VOLTAGE))) {
+        if (bms_get_fault(d->bms_fault, BMSF_CELL_OVER_VOLTAGE)) {
+            d->beep_reason = BEEP_CELL_HV;
+        } else {
+            d->beep_reason = BEEP_HV;
+        }
         beep_alert(d, 3, false);
         if (timer_older(&d->time, d->tb_highvoltage_timer, 0.5) ||
-            d->motor.batt_voltage > d->float_conf.tiltback_hv + 1) {
+            d->motor.batt_voltage > d->float_conf.tiltback_hv + 1 ||
+            bms_get_fault(d->bms_fault, BMSF_CELL_OVER_VOLTAGE)) {
             // 500ms have passed or voltage is another volt higher, time for some tiltback
             if (d->motor.erpm > 0) {
                 d->setpoint_target = d->float_conf.tiltback_hv_angle;
@@ -612,6 +635,17 @@ static void calculate_setpoint_target(Data *d) {
             // The rider has 500ms to react to the triple-beep, or maybe it was just a short spike
             d->state.sat = SAT_NONE;
         }
+
+    } else if (bms_get_fault(d->bms_fault, BMSF_CONNECTION)) {
+        beep_alert(d, 3, true);
+        d->beep_reason = BEEP_BMS_CONNECTION;
+
+        if (d->motor.erpm > 0) {
+            d->setpoint_target = d->float_conf.tiltback_hv_angle;
+        } else {
+            d->setpoint_target = -d->float_conf.tiltback_hv_angle;
+        }
+        d->state.sat = SAT_PB_BMS_CONNECTION;
     } else if (d->motor.mosfet_temp > d->mc_max_temp_fet) {
         // Use the angle from Low-Voltage tiltback, but slower speed from High-Voltage tiltback
         beep_alert(d, 3, true);
@@ -642,9 +676,33 @@ static void calculate_setpoint_target(Data *d) {
             // The rider has 1 degree Celsius left before we start tilting back
             d->state.sat = SAT_NONE;
         }
-    } else if (d->motor.duty_cycle > 0.05 && d->motor.batt_voltage < d->float_conf.tiltback_lv) {
+    } else if (bms_get_fault(d->bms_fault, BMSF_CELL_OVER_TEMP) ||
+               bms_get_fault(d->bms_fault, BMSF_CELL_UNDER_TEMP) ||
+               bms_get_fault(d->bms_fault, BMSF_OVER_TEMP)) {
+        // Use the angle from Low-Voltage tiltback, but slower speed from High-Voltage tiltback
+        beep_alert(d, 3, true);
+        if (bms_get_fault(d->bms_fault, BMSF_CELL_OVER_TEMP)) {
+            d->beep_reason = BEEP_TEMP_CELL_OVER;
+        } else if (bms_get_fault(d->bms_fault, BMSF_CELL_UNDER_TEMP)) {
+            d->beep_reason = BEEP_TEMP_CELL_UNDER;
+        } else {
+            d->beep_reason = BEEP_BMS_TEMP_OVER;
+        }
+        if (d->motor.erpm > 0) {
+            d->setpoint_target = d->float_conf.tiltback_lv_angle;
+        } else {
+            d->setpoint_target = -d->float_conf.tiltback_lv_angle;
+        }
+        d->state.sat = SAT_PB_TEMPERATURE;
+    } else if (d->motor.duty_cycle > 0.05 &&
+               (d->motor.batt_voltage < d->float_conf.tiltback_lv ||
+                bms_get_fault(d->bms_fault, BMSF_CELL_UNDER_VOLTAGE))) {
         beep_alert(d, 3, false);
-        d->beep_reason = BEEP_LV;
+        if (bms_get_fault(d->bms_fault, BMSF_CELL_UNDER_VOLTAGE)) {
+            d->beep_reason = BEEP_CELL_LV;
+        } else {
+            d->beep_reason = BEEP_LV;
+        }
         float abs_motor_current = fabsf(d->motor.dir_current);
         float vdelta = d->float_conf.tiltback_lv - d->motor.batt_voltage;
         float ratio = vdelta * 20 / abs_motor_current;
@@ -652,7 +710,8 @@ static void calculate_setpoint_target(Data *d) {
         // a) we're 2V below lv threshold
         // b) motor current is small (we cannot assume vsag)
         // c) we have more than 20A per Volt of difference (we tolerate some amount of vsag)
-        if ((vdelta > 2) || (abs_motor_current < 5) || (ratio > 1)) {
+        if ((vdelta > 2) || (abs_motor_current < 5) || (ratio > 1) ||
+            bms_get_fault(d->bms_fault, BMSF_CELL_UNDER_VOLTAGE)) {
             if (d->motor.erpm > 0) {
                 d->setpoint_target = d->float_conf.tiltback_lv_angle;
             } else {
@@ -927,6 +986,17 @@ static void refloat_thd(void *arg) {
                 }
                 d->enable_upside_down = false;
                 d->state.darkride = false;
+
+                // Alert user if cells are out of balance
+                if (bms_get_fault(d->bms_fault, BMSF_CELL_BALANCE)) {
+                    beep_alert(d, 1, false);
+                    d->beep_reason = BEEP_CELL_BALANCE;
+                }
+                // Alert user if bms connection failed.
+                if (bms_get_fault(d->bms_fault, BMSF_CONNECTION)) {
+                    beep_alert(d, 1, true);
+                    d->beep_reason = BEEP_BMS_CONNECTION;
+                }
             }
 
             if (time_elapsed(&d->time, idle, 1800)) {  // alert user after 30 minutes
@@ -2042,6 +2112,43 @@ static lbm_value ext_set_fw_version(lbm_value *args, lbm_uint argn) {
     return VESC_IF->lbm_enc_sym_true;
 }
 
+// Called from Lisp to pass in values from the bms. If no prameters are called, return
+// tiltback_bms_enabled.
+static lbm_value ext_bms(lbm_value *args, lbm_uint argn) {
+    Data *d = (Data *) ARG;
+    d->bms_fault = BMSF_NONE;
+
+    if (argn == 0 || !d->float_conf.tiltback_bms_enabled) {
+        return d->float_conf.tiltback_bms_enabled;
+    }
+
+    if (VESC_IF->lbm_dec_as_float(args[5]) > d->float_conf.tiltback_bms_msg) {
+        bms_set_fault(&d->bms_fault, BMSF_CONNECTION);
+        return d->float_conf.tiltback_bms_enabled;
+    }
+    if (VESC_IF->lbm_dec_as_float(args[0]) < d->float_conf.tiltback_cell_lv) {
+        bms_set_fault(&d->bms_fault, BMSF_CELL_UNDER_VOLTAGE);
+    }
+    if (VESC_IF->lbm_dec_as_float(args[1]) > d->float_conf.tiltback_cell_hv) {
+        bms_set_fault(&d->bms_fault, BMSF_CELL_OVER_VOLTAGE);
+    }
+    if (VESC_IF->lbm_dec_as_i32(args[2]) < d->float_conf.tiltback_cell_lt) {
+        bms_set_fault(&d->bms_fault, BMSF_CELL_UNDER_TEMP);
+    }
+    if (VESC_IF->lbm_dec_as_i32(args[3]) > d->float_conf.tiltback_cell_ht) {
+        bms_set_fault(&d->bms_fault, BMSF_CELL_OVER_TEMP);
+    }
+    if (VESC_IF->lbm_dec_as_i32(args[4]) > d->float_conf.tiltback_bms_ht) {
+        bms_set_fault(&d->bms_fault, BMSF_OVER_TEMP);
+    }
+    if (fabsf(VESC_IF->lbm_dec_as_float(args[0]) - VESC_IF->lbm_dec_as_float(args[1])) >
+        d->float_conf.tiltback_cell_bal) {
+        bms_set_fault(&d->bms_fault, BMSF_CELL_BALANCE);
+    }
+
+    return d->float_conf.tiltback_bms_enabled;
+}
+
 // Used to send the current or default configuration to VESC Tool.
 static int get_cfg(uint8_t *buffer, bool is_default) {
     Data *d = (Data *) ARG;
@@ -2160,6 +2267,7 @@ INIT_FUN(lib_info *info) {
     VESC_IF->set_app_data_handler(on_command_received);
     VESC_IF->lbm_add_extension("ext-dbg", ext_dbg);
     VESC_IF->lbm_add_extension("ext-set-fw-version", ext_set_fw_version);
+    VESC_IF->lbm_add_extension("ext-bms", ext_bms);
 
     return true;
 }

--- a/src/state.c
+++ b/src/state.c
@@ -93,6 +93,7 @@ uint8_t sat_compat(const State *state) {
     case SAT_PB_DUTY:
         return 3;  // TILTBACK_DUTY
     case SAT_PB_HIGH_VOLTAGE:
+    case SAT_PB_BMS_CONNECTION:
         return 4;  // TILTBACK_HV
     case SAT_PB_LOW_VOLTAGE:
         return 5;  // TILTBACK_LV

--- a/src/state.h
+++ b/src/state.h
@@ -52,7 +52,8 @@ typedef enum {
     SAT_PB_DUTY = 6,
     SAT_PB_HIGH_VOLTAGE = 10,
     SAT_PB_LOW_VOLTAGE = 11,
-    SAT_PB_TEMPERATURE = 12
+    SAT_PB_TEMPERATURE = 12,
+    SAT_PB_BMS_CONNECTION = 13
 } SetpointAdjustmentType;
 
 typedef struct {

--- a/ui.qml.in
+++ b/ui.qml.in
@@ -818,7 +818,8 @@ Item {
         readonly property int sat_HighVoltage: 10
         readonly property int sat_LowVoltage: 11
         readonly property int sat_Temperature: 12
-
+        readonly property int sat_BMSConnection: 13
+        
         // setpoint adjustment class
         readonly property int sac_Normal: 0
         readonly property int sac_Warning: 1
@@ -832,6 +833,7 @@ Item {
             [sat_HighVoltage, "pushback: high voltage"],
             [sat_LowVoltage, "pushback: low voltage"],
             [sat_Temperature, "pushback: temperature"],
+            [sat_BMSConnection, "pushback: bms connection"],
         ])
 
         property int setpointAdjustmentType: sat_None
@@ -881,6 +883,13 @@ Item {
             [8, "Low Battery"],
             [9, "Board Idle"],
             [10, "Other"],
+            [11, "BMS: Cell Under Temp"],
+            [12, "BMS: Cell Over Temp"],
+            [13, "BMS: Cell Low Voltage"],
+            [14, "BMS: Cell High Voltage"],
+            [15, "BMS: Cell Balance"],
+            [16, "BMS: Connection Lost"],
+            [17, "BMS: BMS Temp"],
         ])
 
         property int beepReason: 0


### PR DESCRIPTION
Rewritten to use variables in Refloat configuration for all parameters as an alternative to https://github.com/lukash/refloat/pull/27 . Made lisp portion much smaller and am just going to do processing in C (need to anyways to access float_conf). Lisp takes up eeprom space and is not compiler optimized like C.

There are no hard coded parameters now. All comments were addressed from other PR with this rewrite. All features tested and confirmed working.

Requires 6.0+ firmware.

6.06 has easy methods that I merged upstream that are more efficient and will use those if detected:

```
(get-bms-val 'bms-v-cell-min)
(get-bms-val 'bms-v-cell-max)
```

Also on 6.06 it will also attempt to get the actual minimum cell temperature (as opposed to just using the max cell temperature as a fall back) as well as the bms mosfet temperature. This relies on the BMS being updated to the new protocol which can be checked with (get-bms-val 'bms-data-version). If you want to learn more please refer to LispBM manual.

Everything will provide tiltback except the cell balance. It will start beeping 10 second after disengage (giving it time to settle) before alerting if criteria is met.