### PR TITLE
Fixed remote not resetting setpoint on 3-stage or EMA filters

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -28,6 +28,9 @@ void remote_init(Remote *remote) {
 void remote_reset(Remote *remote) {
     remote->setpoint = 0;
     remote->ramped_step_size = 0;
+
+    smooth_target_reset(&remote->smooth_target, 0.0f);
+    ema_filter_reset(&remote->ema_target, 0.0f, 0.0f);
 }
 
 void remote_configure(Remote *remote, const RefloatConfig *config) {


### PR DESCRIPTION
Fix: Remote now properly resets setpoint for 3-Stage and EMA filters on Engage