### PR TITLE
Fixed logic for tilt/release speed conditions

### DIFF
--- a/src/atr.c
+++ b/src/atr.c
@@ -56,7 +56,7 @@ void atr_configure(ATR *atr, const RefloatConfig *config) {
     );
 }
 
-void atr_update(ATR *atr, const MotorData *motor, const RefloatConfig *config, float dt) {
+static float calculate_atr_target(ATR *atr, const MotorData *motor, const RefloatConfig *config) {
     float abs_torque = fabsf(motor->filt_current);
     float torque_offset = 8;  // hard-code to 8A for now (shouldn't really be changed much anyways)
     float atr_threshold = motor->braking ? config->atr_threshold_down : config->atr_threshold_up;
@@ -199,6 +199,21 @@ void atr_update(ATR *atr, const MotorData *motor, const RefloatConfig *config, f
         atr_step_size /= 2;
     }
 
+    return atr_step_size;
+}
+
+void atr_update(
+    ATR *atr, const MotorData *motor, const RefloatConfig *config, bool wheelslip, float dt
+) {
+    float atr_step_size = 0;
+
+    if (!wheelslip) {
+        atr_step_size = calculate_atr_target(atr, motor, config);
+    } else {
+        atr->target *= 0.99;
+        atr_step_size = atr->off_step_size;
+    }
+
     if (config->target_filter.type == SFT_NONE) {
         rate_limitf(&atr->setpoint, atr->target, atr_step_size);
     } else if (config->target_filter.type == SFT_EMA3) {
@@ -211,9 +226,4 @@ void atr_update(ATR *atr, const MotorData *motor, const RefloatConfig *config, f
         // Smoothen changes in tilt angle by ramping the step size
         smooth_rampf(&atr->setpoint, &atr->ramped_step_size, atr->target, atr_step_size, 0.05, 1.5);
     }
-}
-
-void atr_winddown(ATR *atr) {
-    atr->setpoint *= 0.995;
-    atr->target *= 0.99;
 }

--- a/src/atr.h
+++ b/src/atr.h
@@ -19,7 +19,9 @@
 #pragma once
 
 #include "conf/datatypes.h"
+#include "ema_filter.h"
 #include "motor_data.h"
+#include "smooth_target.h"
 
 typedef struct {
     float on_step_size;
@@ -33,12 +35,15 @@ typedef struct {
     float setpoint;
 
     float speed_boost_mult;
+
+    SmoothTarget smooth_target;
+    EMAFilter ema_target;
 } ATR;
 
 void atr_reset(ATR *atr);
 
 void atr_configure(ATR *atr, const RefloatConfig *config);
 
-void atr_update(ATR *atr, const MotorData *motor, const RefloatConfig *config);
+void atr_update(ATR *atr, const MotorData *motor, const RefloatConfig *config, float dt);
 
 void atr_winddown(ATR *atr);

--- a/src/atr.h
+++ b/src/atr.h
@@ -44,6 +44,6 @@ void atr_reset(ATR *atr);
 
 void atr_configure(ATR *atr, const RefloatConfig *config);
 
-void atr_update(ATR *atr, const MotorData *motor, const RefloatConfig *config, float dt);
-
-void atr_winddown(ATR *atr);
+void atr_update(
+    ATR *atr, const MotorData *motor, const RefloatConfig *config, bool wheelslip, float dt
+);

--- a/src/brake_tilt.c
+++ b/src/brake_tilt.c
@@ -41,8 +41,15 @@ void brake_tilt_update(
     const MotorData *motor,
     const ATR *atr,
     const RefloatConfig *config,
+    bool wheelslip,
     float balance_offset
 ) {
+    if (wheelslip) {
+        bt->target *= 0.99;
+        bt->setpoint = bt->target;
+        return;
+    }
+
     // braking also should cause setpoint change lift, causing a delayed lingering nose lift
     if (bt->factor < 0 && motor->braking && motor->abs_erpm > 2000) {
         // negative currents alone don't necessarily constitute active braking, look at
@@ -77,9 +84,4 @@ void brake_tilt_update(
     }
 
     rate_limitf(&bt->setpoint, bt->target, braketilt_step_size);
-}
-
-void brake_tilt_winddown(BrakeTilt *bt) {
-    bt->setpoint *= 0.995;
-    bt->target *= 0.99;
 }

--- a/src/brake_tilt.h
+++ b/src/brake_tilt.h
@@ -37,7 +37,6 @@ void brake_tilt_update(
     const MotorData *motor,
     const ATR *atr,
     const RefloatConfig *config,
+    bool wheelslip,
     float balance_offset
 );
-
-void brake_tilt_winddown(BrakeTilt *bt);

--- a/src/conf/datatypes.h
+++ b/src/conf/datatypes.h
@@ -182,6 +182,24 @@ typedef struct {
     float current_threshold;
 } CfgHapticFeedback;
 
+typedef enum {
+    SFT_NONE = 0,
+    SFT_THREE_STAGE,
+    SFT_EMA3,
+    SFT_NICO
+} TargetFilterType;
+
+typedef struct {
+    TargetFilterType type;
+    TargetFilterType tt_type;
+    TargetFilterType it_type;
+    float alpha;
+    float in_alpha_away;
+    float in_alpha_back;
+    float ema_half_time;
+    float ema_return_multiplier;
+} CfgTargetFilter;
+
 typedef struct {
     bool is_default;
 } CfgMeta;
@@ -195,6 +213,7 @@ typedef struct {
     float mahony_kp_roll;
     float kp_brake;
     float kp2_brake;
+    CfgTargetFilter target_filter;
     uint16_t hertz;
     float fault_pitch;
     float fault_roll;

--- a/src/conf/settings.xml
+++ b/src/conf/settings.xml
@@ -221,6 +221,195 @@ p, li { white-space: pre-wrap; }
             <suffix>x</suffix>
             <vTx>7</vTx>
         </kp2_brake>
+        <target_filter.type>
+            <longName>Filter Type</longName>
+            <type>4</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Target Filter to use for ATR.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Torque Tilt and Input Tilt have their own options for the type of filter, but the particular filter configuration is always taken from the options below this one, because we are limited in memory available to store all the options. Since each filter has its own separate configuration, you can set a different type to each kind of Tilt to be able to have them configured differently.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;None&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;No target filtering (old, baseline behavior).&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;3-Stage&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A custom filter designed to allow fine control of the different transitions.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The 3-Stage Alpha option controls the overall smoothness and primarily the shape out of transitions to a new target. The 3-Stage In Alpha Away From Zero controls the shape into a transition towards an away-from-zero setpoint and 3-Stage Alpha Back To Zero controls the shape into a transition when returning back to zero.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The idea here is you want to transition into extreme setpoints slower, but return from them faster to avoid unwanted lingering tiltback.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The 3-Stage filter has a property that during vibrations, it (counterintuitively) goes to zero slower than it goes up. In practice this means when going over chunk, the setpoint will raise up slightly, which can be very beneficial.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Known drawbacks: During curb nudges, the filter tends to shoot up the nose as you nudge up the curb.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;3rd Order EMA&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A 3rd order EMA (Exponential Moving Average) which approximates the Gaussian filter. This is a standard filter with predictable results which shouldn't have any side-effects.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;It's defined by the EMA Half Time config option. You can use the EMA Return Multiplier to speed up transitions returning to zero (e.g. a value of 2 means the returning to zero transitions will be two times faster).&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Nico's&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A smoothing filter written by Nico originally for Inputtilt, it was later proposed to be used tor ATR and Torquetilt as well. Although this filter works and is reported to work very well, it has a mathematical flaw, and hence is only included for reference. The other filters are, in fact, an attempt to have correct filter(s) that work the same or better.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note: The 3-Stage and 3rd Order EMA ignore Tiltback Response Boost and Tiltback Transition Boost for ATR.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TARGET_FILTER_TYPE</cDefine>
+            <valInt>1</valInt>
+            <enumNames>None</enumNames>
+            <enumNames>3-Stage</enumNames>
+            <enumNames>3rd Order EMA</enumNames>
+            <enumNames>Nico's</enumNames>
+        </target_filter.type>
+        <target_filter.tt_type>
+            <longName>Filter Type (config on ATR tab)</longName>
+            <type>4</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Target Filter to use for Torque Tilt.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The particular filter's configuration is taken from the ATR tab. See description of ATR -&amp;gt; Filter Type for more info on the available filters.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TARGET_FILTER_TT_TYPE</cDefine>
+            <valInt>1</valInt>
+            <enumNames>None</enumNames>
+            <enumNames>3-Stage</enumNames>
+            <enumNames>3rd Order EMA</enumNames>
+            <enumNames>Nico's</enumNames>
+        </target_filter.tt_type>
+        <target_filter.it_type>
+            <longName>Filter Type (config on ATR tab)</longName>
+            <type>4</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Target Filter to use for Input Tilt.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The particular filter's configuration is taken from the ATR tab. See description of ATR -&amp;gt; Filter Type for more info on the available filters.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TARGET_FILTER_IT_TYPE</cDefine>
+            <valInt>0</valInt>
+            <enumNames>Nico's</enumNames>
+            <enumNames>3-Stage</enumNames>
+            <enumNames>3rd Order EMA</enumNames>
+        </target_filter.it_type>
+        <target_filter.alpha>
+            <longName>3-Stage Alpha</longName>
+            <type>1</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The base alpha for the 3-Stage filter, defines the overall curve shape. Higher numbers mean less filtering, recommended between 0.01 (quite strong filtering) and 0.02 (low amount of filtering). You can use the 3-Stage In Alpha Away From Zero and 3-Stage In Alpha Back To Zero options to futher slow down the &amp;quot;ease into&amp;quot; away from and back to zero transitions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_target_filter_ALPHA</cDefine>
+            <editorDecimalsDouble>3</editorDecimalsDouble>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxDouble>1</maxDouble>
+            <minDouble>0</minDouble>
+            <showDisplay>0</showDisplay>
+            <stepDouble>0.002</stepDouble>
+            <valDouble>0.01</valDouble>
+            <vTxDoubleScale>10000</vTxDoubleScale>
+            <suffix></suffix>
+            <vTx>7</vTx>
+        </target_filter.alpha>
+        <target_filter.in_alpha_away>
+            <longName>3-Stage In Alpha Away From Zero</longName>
+            <type>1</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ease in alpha for the 3-Stage filter when going away from zero into a tiltback. Higher numbers mean less filtering, recommended between 0.2 (minimal filtering) and 0.002 (heavy filtering). Set it to 1 to eliminate any slowdown of the transition.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TARGET_FILTER_IN_ALPHA_AWAY</cDefine>
+            <editorDecimalsDouble>3</editorDecimalsDouble>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxDouble>1</maxDouble>
+            <minDouble>0.001</minDouble>
+            <showDisplay>0</showDisplay>
+            <stepDouble>0.001</stepDouble>
+            <valDouble>0.004</valDouble>
+            <vTxDoubleScale>10000</vTxDoubleScale>
+            <suffix></suffix>
+            <vTx>7</vTx>
+        </target_filter.in_alpha_away>
+        <target_filter.in_alpha_back>
+            <longName>3-Stage In Alpha Back To Zero</longName>
+            <type>1</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ease in alpha for the 3-Stage filter when going towards zero from a tiltback. Higher numbers mean less filtering, recommended between 0.2 (minimal filtering) and 0.01 (heavy filtering). Set it to 1 to eliminate any slowdown of the transition.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TARGET_FILTER_IN_ALPHA_BACK</cDefine>
+            <editorDecimalsDouble>3</editorDecimalsDouble>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxDouble>1</maxDouble>
+            <minDouble>0.001</minDouble>
+            <showDisplay>0</showDisplay>
+            <stepDouble>0.01</stepDouble>
+            <valDouble>0.05</valDouble>
+            <vTxDoubleScale>10000</vTxDoubleScale>
+            <suffix></suffix>
+            <vTx>7</vTx>
+        </target_filter.in_alpha_back>
+        <target_filter.ema_half_time>
+            <longName>EMA Half Time</longName>
+            <type>1</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Half Time (time it takes to reach half the target value) of the 3rd order EMA filter, which approximates a Gaussian filter. Higher values mean more filtering.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;(equivalent of alpha of the 3-Stage and other filters, it's intended to present a number that's easier to understand)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_EMA_FILTER_HALF_TIME</cDefine>
+            <editorDecimalsDouble>0</editorDecimalsDouble>
+            <editorScale>1000</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxDouble>2</maxDouble>
+            <minDouble>0.02</minDouble>
+            <showDisplay>0</showDisplay>
+            <stepDouble>20</stepDouble>
+            <valDouble>0.36</valDouble>
+            <vTxDoubleScale>1000</vTxDoubleScale>
+            <suffix> ms</suffix>
+            <vTx>7</vTx>
+        </target_filter.ema_half_time>
+        <target_filter.ema_return_multiplier>
+            <longName>EMA Return Multiplier</longName>
+            <type>1</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Multiplier for the return to zero filter speed of the 3rd order EMA filter. E.g. setting this to 2 will mean the change back to zero will be twice as fast than going away from zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_EMA_FILTER_RETURN_MULTIPLIER</cDefine>
+            <editorDecimalsDouble>2</editorDecimalsDouble>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxDouble>10</maxDouble>
+            <minDouble>0.1</minDouble>
+            <showDisplay>0</showDisplay>
+            <stepDouble>0.2</stepDouble>
+            <valDouble>2</valDouble>
+            <vTxDoubleScale>1000</vTxDoubleScale>
+            <suffix></suffix>
+            <vTx>7</vTx>
+        </target_filter.ema_return_multiplier>
         <hertz>
             <longName>Loop Hertz</longName>
             <type>2</type>
@@ -1713,8 +1902,8 @@ p, li { white-space: pre-wrap; }
             <maxDouble>100</maxDouble>
             <minDouble>0</minDouble>
             <showDisplay>0</showDisplay>
-            <stepDouble>0.5</stepDouble>
-            <valDouble>10</valDouble>
+            <stepDouble>2</stepDouble>
+            <valDouble>20</valDouble>
             <vTxDoubleScale>100</vTxDoubleScale>
             <suffix> °/s</suffix>
             <vTx>7</vTx>
@@ -1735,8 +1924,8 @@ p, li { white-space: pre-wrap; }
             <maxDouble>100</maxDouble>
             <minDouble>0</minDouble>
             <showDisplay>0</showDisplay>
-            <stepDouble>0.5</stepDouble>
-            <valDouble>8</valDouble>
+            <stepDouble>2</stepDouble>
+            <valDouble>20</valDouble>
             <vTxDoubleScale>100</vTxDoubleScale>
             <suffix> °/s</suffix>
             <vTx>7</vTx>
@@ -1954,8 +2143,8 @@ p, li { white-space: pre-wrap; }
             <maxDouble>100</maxDouble>
             <minDouble>0</minDouble>
             <showDisplay>0</showDisplay>
-            <stepDouble>0.5</stepDouble>
-            <valDouble>10</valDouble>
+            <stepDouble>2</stepDouble>
+            <valDouble>20</valDouble>
             <vTxDoubleScale>100</vTxDoubleScale>
             <suffix> °/s</suffix>
             <vTx>7</vTx>
@@ -1976,8 +2165,8 @@ p, li { white-space: pre-wrap; }
             <maxDouble>100</maxDouble>
             <minDouble>0</minDouble>
             <showDisplay>0</showDisplay>
-            <stepDouble>0.5</stepDouble>
-            <valDouble>8</valDouble>
+            <stepDouble>2</stepDouble>
+            <valDouble>20</valDouble>
             <vTxDoubleScale>100</vTxDoubleScale>
             <suffix> °/s</suffix>
             <vTx>7</vTx>
@@ -3692,6 +3881,14 @@ p, li { white-space: pre-wrap; }
         <ser>mahony_kp_roll</ser>
         <ser>kp_brake</ser>
         <ser>kp2_brake</ser>
+        <ser>target_filter.type</ser>
+        <ser>target_filter.tt_type</ser>
+        <ser>target_filter.it_type</ser>
+        <ser>target_filter.alpha</ser>
+        <ser>target_filter.in_alpha_away</ser>
+        <ser>target_filter.in_alpha_back</ser>
+        <ser>target_filter.ema_half_time</ser>
+        <ser>target_filter.ema_return_multiplier</ser>
         <ser>hertz</ser>
         <ser>fault_pitch</ser>
         <ser>fault_roll</ser>
@@ -3884,6 +4081,7 @@ p, li { white-space: pre-wrap; }
                     <param>torquetilt_strength_regen</param>
                     <param>torquetilt_start_current</param>
                     <param>torquetilt_angle_limit</param>
+                    <param>target_filter.tt_type</param>
                     <param>torquetilt_on_speed</param>
                     <param>torquetilt_off_speed</param>
                     <param>::sep::Turn Tiltback</param>
@@ -3906,6 +4104,13 @@ p, li { white-space: pre-wrap; }
                     <param>atr_threshold_up</param>
                     <param>atr_threshold_down</param>
                     <param>atr_speed_boost</param>
+                    <param>::sep::Filtering (also for Torque Tilt and Input Tilt)</param>
+                    <param>target_filter.type</param>
+                    <param>target_filter.alpha</param>
+                    <param>target_filter.in_alpha_away</param>
+                    <param>target_filter.in_alpha_back</param>
+                    <param>target_filter.ema_half_time</param>
+                    <param>target_filter.ema_return_multiplier</param>
                     <param>::sep::Nose Angling</param>
                     <param>atr_angle_limit</param>
                     <param>atr_on_speed</param>
@@ -4002,6 +4207,7 @@ p, li { white-space: pre-wrap; }
                     <param>inputtilt_remote_type</param>
                     <param>inputtilt_angle_limit</param>
                     <param>inputtilt_speed</param>
+                    <param>target_filter.it_type</param>
                     <param>inputtilt_invert_throttle</param>
                     <param>inputtilt_deadband</param>
                     <param>::sep::Remote Throttle</param>

--- a/src/data.h
+++ b/src/data.h
@@ -99,6 +99,7 @@ typedef struct {
     float setpoint, setpoint_target, setpoint_target_interpolated;
     float noseangling_interpolated;
     time_t nag_timer;
+    float dt;
     float idle_voltage;
     time_t fault_angle_pitch_timer, fault_angle_roll_timer, fault_switch_timer,
         fault_switch_half_timer;

--- a/src/ema_filter.c
+++ b/src/ema_filter.c
@@ -51,10 +51,12 @@ void ema_filter_update(EMAFilter *filter, float target, float dt) {
     filter->speed += dt * filter->accel;
 
     uint16_t speed_limit;
-    if (sign(filter->speed) == sign(filter->value)) {
-        speed_limit = filter->on_speed;
-    } else {
+    if ((filter->value * target >= 0) && (fabsf(filter->value) > fabsf(target))) {
+        // Moving towards smaller angle of same sign or zero
         speed_limit = filter->off_speed;
+    } else {
+        // Moving towards larger angle of same sign or crossing zero
+        speed_limit = filter->on_speed;
     }
     filter->value += dt * sign(filter->speed) * min(fabsf(filter->speed), speed_limit);
 }

--- a/src/ema_filter.c
+++ b/src/ema_filter.c
@@ -1,0 +1,60 @@
+// Copyright 2024 Lukas Hrazky
+//
+// This file is part of the Refloat VESC package.
+//
+// Refloat VESC package is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Refloat VESC package is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <http://www.gnu.org/licenses/>.
+
+#include "ema_filter.h"
+
+#include "utils.h"
+
+#include <math.h>
+
+void ema_filter_configure(
+    EMAFilter *filter, const CfgTargetFilter *cfg, float on_speed, float off_speed
+) {
+    filter->cfg = *cfg;
+    filter->k = 0.693f / max(cfg->ema_half_time, 0.001f);
+    filter->on_speed = on_speed;
+    filter->off_speed = off_speed;
+}
+
+void ema_filter_reset(EMAFilter *filter, float value, float speed) {
+    filter->value = value;
+    filter->speed = speed;
+    filter->accel = 0.0f;
+}
+
+void ema_filter_update(EMAFilter *filter, float target, float dt) {
+    float k = filter->k;
+    if (fabsf(target) < fabsf(filter->value)) {
+        k *= filter->cfg.ema_return_multiplier;
+    }
+
+    // Coefficients chosen to approximate Gaussian filter and preserve half time
+    float speed = 1.34f * k * (target - filter->value);
+    float accel = 3.62f * k * (speed - filter->speed);
+    float jerk = 9.77f * k * (accel - filter->accel);
+
+    filter->accel += dt * jerk;
+    filter->speed += dt * filter->accel;
+
+    uint16_t speed_limit;
+    if (sign(filter->speed) == sign(filter->value)) {
+        speed_limit = filter->on_speed;
+    } else {
+        speed_limit = filter->off_speed;
+    }
+    filter->value += dt * sign(filter->speed) * min(fabsf(filter->speed), speed_limit);
+}

--- a/src/ema_filter.h
+++ b/src/ema_filter.h
@@ -1,4 +1,4 @@
-// Copyright 2025 Lukas Hrazky
+// Copyright 2024 Lukas Hrazky
 //
 // This file is part of the Refloat VESC package.
 //
@@ -18,27 +18,23 @@
 #pragma once
 
 #include "conf/datatypes.h"
-#include "ema_filter.h"
-#include "smooth_target.h"
-#include "state.h"
 
 typedef struct {
-    float step_size;
+    CfgTargetFilter cfg;
+    float on_speed;
+    float off_speed;
 
-    float input;
-    float ramped_step_size;
-    SmoothTarget smooth_target;
-    EMAFilter ema_target;
+    float value;
+    float speed;
+    float accel;
+    float k;
+    float dt;
+} EMAFilter;
 
-    float setpoint;
-} Remote;
+void ema_filter_configure(
+    EMAFilter *filter, const CfgTargetFilter *cfg, float on_speed, float off_speed
+);
 
-void remote_init(Remote *remote);
+void ema_filter_reset(EMAFilter *filter, float value, float speed);
 
-void remote_reset(Remote *remote);
-
-void remote_configure(Remote *remote, const RefloatConfig *config);
-
-void remote_input(Remote *remote, const RefloatConfig *config);
-
-void remote_update(Remote *remote, const State *state, const RefloatConfig *config, float dt);
+void ema_filter_update(EMAFilter *filter, float target, float dt);

--- a/src/imu.c
+++ b/src/imu.c
@@ -33,14 +33,22 @@ void imu_init(IMU *imu) {
 }
 
 void imu_update(IMU *imu, const BalanceFilterData *bf, const State *state) {
+    float roll_rad = VESC_IF->imu_get_roll();  // in Radians
+
     imu->pitch = rad2deg(VESC_IF->imu_get_pitch());
-    imu->roll = rad2deg(VESC_IF->imu_get_roll());
+    imu->roll = rad2deg(roll_rad);
     imu->yaw = rad2deg(VESC_IF->imu_get_yaw());
     imu->balance_pitch = rad2deg(balance_filter_get_pitch(bf));
 
     float gyro[3];
     VESC_IF->imu_get_gyro(gyro);
-    imu->gyro_y = gyro[1];
+
+    float sin_roll = sinf(roll_rad);
+    float cos_roll = cosf(roll_rad);
+
+    // Rotated to diminish influence of Yaw Change on Gyro Y when board is rolled
+    // (Estimates Pitch Rate solely due to rider input, without influence from board turning)
+    imu->gyro_y = cos_roll * cos_roll * gyro[1] + sin_roll * cos_roll * gyro[2];
 
     if (state->mode == MODE_FLYWHEEL) {
         imu->pitch = imu->flywheel_pitch_offset - imu->pitch;

--- a/src/main.c
+++ b/src/main.c
@@ -172,6 +172,8 @@ static void configure(Data *d) {
 
     lcm_configure(&d->lcm, &d->float_conf.leds);
 
+    d->dt = 1.0f / d->float_conf.hertz;
+
     // Loop time in microseconds
     d->loop_time_us = 1e6 / d->float_conf.hertz;
 
@@ -796,7 +798,7 @@ static void refloat_thd(void *arg) {
             );
             d->setpoint = d->setpoint_target_interpolated;
 
-            remote_update(&d->remote, &d->state, &d->float_conf);
+            remote_update(&d->remote, &d->state, &d->float_conf, d->dt);
             d->setpoint += d->remote.setpoint;
 
             if (!d->state.darkride) {
@@ -820,8 +822,8 @@ static void refloat_thd(void *arg) {
                     );
                     d->setpoint += d->turn_tilt.setpoint;
 
-                    torque_tilt_update(&d->torque_tilt, &d->motor, &d->float_conf);
-                    atr_update(&d->atr, &d->motor, &d->float_conf);
+                    torque_tilt_update(&d->torque_tilt, &d->motor, &d->float_conf, d->dt);
+                    atr_update(&d->atr, &d->motor, &d->float_conf, d->dt);
                     brake_tilt_update(
                         &d->brake_tilt,
                         &d->motor,

--- a/src/main.c
+++ b/src/main.c
@@ -518,7 +518,6 @@ static void calculate_setpoint_target(Data *d) {
                     d->state.sat = SAT_NONE;
                     d->reverse_total_erpm = 0;
                     d->setpoint_target = 0;
-                    pid_reset_integral(&d->pid);
                 }
             }
         }
@@ -844,7 +843,7 @@ static void refloat_thd(void *arg) {
                 }
             }
 
-            pid_update(&d->pid, d->setpoint, &d->motor, &d->imu, &d->state, &d->float_conf);
+            pid_update(&d->pid, d->setpoint, &d->motor, &d->imu, &d->float_conf);
 
             float booster_proportional = d->setpoint - d->brake_tilt.setpoint - d->imu.pitch;
             booster_update(&d->booster, &d->motor, &d->float_conf, booster_proportional);

--- a/src/main.c
+++ b/src/main.c
@@ -804,11 +804,7 @@ static void refloat_thd(void *arg) {
             if (!d->state.darkride) {
                 // in case of wheelslip, don't change torque tilts, instead slightly decrease each
                 // cycle
-                if (d->state.wheelslip) {
-                    torque_tilt_winddown(&d->torque_tilt);
-                    atr_winddown(&d->atr);
-                    brake_tilt_winddown(&d->brake_tilt);
-                } else {
+                if (!d->state.wheelslip) {
                     apply_noseangling(d);
                     d->setpoint += d->noseangling_interpolated;
 
@@ -821,17 +817,20 @@ static void refloat_thd(void *arg) {
                         &d->float_conf
                     );
                     d->setpoint += d->turn_tilt.setpoint;
-
-                    torque_tilt_update(&d->torque_tilt, &d->motor, &d->float_conf, d->dt);
-                    atr_update(&d->atr, &d->motor, &d->float_conf, d->dt);
-                    brake_tilt_update(
-                        &d->brake_tilt,
-                        &d->motor,
-                        &d->atr,
-                        &d->float_conf,
-                        d->setpoint - d->imu.balance_pitch
-                    );
                 }
+
+                torque_tilt_update(
+                    &d->torque_tilt, &d->motor, &d->float_conf, d->state.wheelslip, d->dt
+                );
+                atr_update(&d->atr, &d->motor, &d->float_conf, d->state.wheelslip, d->dt);
+                brake_tilt_update(
+                    &d->brake_tilt,
+                    &d->motor,
+                    &d->atr,
+                    &d->float_conf,
+                    d->state.wheelslip,
+                    d->setpoint - d->imu.balance_pitch
+                );
 
                 // aggregated torque tilts:
                 // if signs match between torque tilt and ATR + brake tilt, use the more significant

--- a/src/main.c
+++ b/src/main.c
@@ -977,20 +977,36 @@ static void refloat_thd(void *arg) {
     }
 }
 
+// TODO: The required buffer size is not provided by the confparser. Until it's
+// added, use a number that should always be bigger. On a config write, we
+// check if we've written past the buffer end and crash. On a config read,
+// there's no way to check and the trailing end of the config will have bogus
+// numbers read from the EEPROM.
+#ifndef SERIALIZED_CONFIG_LENGTH
+#define SERIALIZED_CONFIG_LENGTH 320
+#endif
+
 static void write_cfg_to_eeprom(Data *d) {
-    uint32_t ints = sizeof(RefloatConfig) / 4 + 1;
-    uint32_t *buffer = VESC_IF->malloc(ints * sizeof(uint32_t));
+    const size_t words = (SERIALIZED_CONFIG_LENGTH - 1) / 4 + 1;
+    const size_t bufsize = words * 4;
+    uint32_t *buffer = VESC_IF->malloc(bufsize);
     if (!buffer) {
-        log_error("Failed to write config to EEPROM: Out of memory.");
+        log_error("Failed to write config: Out of memory.");
         return;
+    }
+    memset(buffer, 0, bufsize);
+
+    uint32_t written_bytes = confparser_serialize_refloatconfig((uint8_t *) buffer, &d->float_conf);
+    if (written_bytes > bufsize) {
+        log_error("Config write buffer overflow, terminating.");
+        fatal_error_terminate();
     }
 
     bool write_ok = true;
-    memcpy(buffer, &(d->float_conf), sizeof(RefloatConfig));
-    for (uint32_t i = 0; i < ints; i++) {
+    for (uint32_t i = 0; i < words; ++i) {
         eeprom_var v;
         v.as_u32 = buffer[i];
-        if (!VESC_IF->store_eeprom_var(&v, i + 1)) {
+        if (!VESC_IF->store_eeprom_var(&v, i)) {
             write_ok = false;
             break;
         }
@@ -999,14 +1015,11 @@ static void write_cfg_to_eeprom(Data *d) {
     VESC_IF->free(buffer);
 
     if (write_ok) {
-        eeprom_var v;
-        v.as_u32 = REFLOATCONFIG_SIGNATURE;
-        VESC_IF->store_eeprom_var(&v, 0);
-
+        log_msg("Config written: %uB", written_bytes);
         beep_alert(d, 1, 0);
         leds_status_confirm(&d->leds);
     } else {
-        log_error("Failed to write config to EEPROM.");
+        log_error("Failed to write config.");
     }
 }
 
@@ -1027,35 +1040,30 @@ static void aux_thd(void *arg) {
 }
 
 static void read_cfg_from_eeprom(Data *d) {
-    uint32_t ints = sizeof(RefloatConfig) / 4 + 1;
-    uint32_t *buffer = VESC_IF->malloc(ints * sizeof(uint32_t));
+    uint32_t words = (SERIALIZED_CONFIG_LENGTH - 1) / 4 + 1;
+    uint32_t *buffer = VESC_IF->malloc(words * sizeof(uint32_t));
     if (!buffer) {
-        log_error("Failed to read config from EEPROM: Out of memory.");
+        log_error("Failed to read config: Out of memory.");
         return;
     }
 
     eeprom_var v;
-    bool read_ok = VESC_IF->read_eeprom_var(&v, 0);
-    if (read_ok) {
-        if (v.as_u32 == REFLOATCONFIG_SIGNATURE) {
-            for (uint32_t i = 0; i < ints; i++) {
-                if (!VESC_IF->read_eeprom_var(&v, i + 1)) {
-                    read_ok = false;
-                    break;
-                }
-                buffer[i] = v.as_u32;
-            }
-        } else {
-            log_error("Failed signature check while reading config from EEPROM, using defaults.");
-            confparser_set_defaults_refloatconfig(&d->float_conf);
-            return;
+    bool read_ok = true;
+    for (uint32_t i = 0; i < words; ++i) {
+        if (!VESC_IF->read_eeprom_var(&v, i)) {
+            read_ok = false;
+            break;
         }
+        buffer[i] = v.as_u32;
     }
 
     if (read_ok) {
-        memcpy(&d->float_conf, buffer, sizeof(RefloatConfig));
+        if (!confparser_deserialize_refloatconfig((uint8_t *) buffer, &d->float_conf)) {
+            log_error("Failed to deserialize config, using defaults.");
+            confparser_set_defaults_refloatconfig(&d->float_conf);
+        }
     } else {
-        log_error("Failed to read config from EEPROM, using defaults.");
+        log_error("Failed to read config, using defaults.");
         confparser_set_defaults_refloatconfig(&d->float_conf);
     }
 
@@ -2259,6 +2267,6 @@ INIT_FUN(lib_info *info) {
     return true;
 }
 
-void send_app_data_overflow_terminate() {
+void fatal_error_terminate() {
     stop(ARG);
 }

--- a/src/pid.c
+++ b/src/pid.c
@@ -35,12 +35,7 @@ void pid_init(PID *pid) {
 }
 
 void pid_update(
-    PID *pid,
-    float setpoint,
-    const MotorData *md,
-    const IMU *imu,
-    const State *state,
-    const RefloatConfig *config
+    PID *pid, float setpoint, const MotorData *md, const IMU *imu, const RefloatConfig *config
 ) {
     pid->p = setpoint - imu->balance_pitch;
     pid->i = pid->i + pid->p * config->ki;
@@ -48,10 +43,6 @@ void pid_update(
     // I term filter
     if (config->ki_limit > 0 && fabsf(pid->i) > config->ki_limit) {
         pid->i = config->ki_limit * sign(pid->i);
-    }
-    // quickly ramp down integral component during reverse stop
-    if (state->sat == SAT_REVERSESTOP) {
-        pid->i *= 0.9;
     }
 
     // brake scale coefficient smoothing
@@ -79,8 +70,4 @@ void pid_update(
 
     pid->rate_p = -imu->gyro_y * config->kp2;
     pid->rate_p *= pid->rate_p > 0 ? pid->kp2_accel_scale : pid->kp2_brake_scale;
-}
-
-void pid_reset_integral(PID *pid) {
-    pid->i = 0;
 }

--- a/src/pid.h
+++ b/src/pid.h
@@ -20,7 +20,6 @@
 #include "conf/datatypes.h"
 #include "imu.h"
 #include "motor_data.h"
-#include "state.h"
 
 typedef struct {
     float p;
@@ -37,12 +36,5 @@ typedef struct {
 void pid_init(PID *pid);
 
 void pid_update(
-    PID *pid,
-    float setpoint,
-    const MotorData *md,
-    const IMU *imu,
-    const State *state,
-    const RefloatConfig *config
+    PID *pid, float setpoint, const MotorData *md, const IMU *imu, const RefloatConfig *config
 );
-
-void pid_reset_integral(PID *pid);

--- a/src/remote.c
+++ b/src/remote.c
@@ -28,6 +28,9 @@ void remote_init(Remote *remote) {
 void remote_reset(Remote *remote) {
     remote->setpoint = 0;
     remote->ramped_step_size = 0;
+
+    smooth_target_reset(&remote->smooth_target, 0.0f);
+    ema_filter_reset(&remote->ema_target, 0.0f, 0.0f);
 }
 
 void remote_configure(Remote *remote, const RefloatConfig *config) {

--- a/src/smooth_target.c
+++ b/src/smooth_target.c
@@ -51,10 +51,12 @@ void smooth_target_update(SmoothTarget *st, float target) {
     }
 
     float speed_limit;
-    if (sign(st->step) == sign(st->value)) {
-        speed_limit = st->on_speed;
-    } else {
+    if ((st->value * target >= 0) && (fabsf(st->value) > fabsf(target))) {
+        // Moving towards smaller angle of same sign or zero
         speed_limit = st->off_speed;
+    } else {
+        // Moving towards larger angle of same sign or crossing zero
+        speed_limit = st->on_speed;
     }
 
     st->value += sign(st->step) * min(fabsf(st->step), speed_limit);

--- a/src/smooth_target.c
+++ b/src/smooth_target.c
@@ -1,0 +1,61 @@
+// Copyright 2024 Lukas Hrazky
+//
+// This file is part of the Refloat VESC package.
+//
+// Refloat VESC package is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Refloat VESC package is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <http://www.gnu.org/licenses/>.
+
+#include "smooth_target.h"
+
+#include "utils.h"
+
+#include <math.h>
+
+void smooth_target_configure(
+    SmoothTarget *st, const CfgTargetFilter *cfg, float on_speed, float off_speed, float hertz
+) {
+    st->cfg = *cfg;
+    st->on_speed = on_speed / hertz;
+    st->off_speed = off_speed / hertz;
+}
+
+void smooth_target_reset(SmoothTarget *st, float value) {
+    st->v1 = 0;
+    st->step = 0;
+    st->value = value;
+}
+
+void smooth_target_update(SmoothTarget *st, float target) {
+    st->v1 += st->cfg.alpha * (target - st->v1);
+
+    float delta = st->cfg.alpha * (st->v1 - st->value);
+
+    if (fabsf(delta) > fabsf(st->step) || sign(delta) != sign(st->step)) {
+        if (sign(st->value) == sign(delta)) {
+            st->step += st->cfg.in_alpha_away * (delta - st->step);
+        } else {
+            st->step += st->cfg.in_alpha_back * (delta - st->step);
+        }
+    } else {
+        st->step = delta;
+    }
+
+    float speed_limit;
+    if (sign(st->step) == sign(st->value)) {
+        speed_limit = st->on_speed;
+    } else {
+        speed_limit = st->off_speed;
+    }
+
+    st->value += sign(st->step) * min(fabsf(st->step), speed_limit);
+}

--- a/src/smooth_target.h
+++ b/src/smooth_target.h
@@ -1,4 +1,4 @@
-// Copyright 2025 Lukas Hrazky
+// Copyright 2024 Lukas Hrazky
 //
 // This file is part of the Refloat VESC package.
 //
@@ -18,27 +18,21 @@
 #pragma once
 
 #include "conf/datatypes.h"
-#include "ema_filter.h"
-#include "smooth_target.h"
-#include "state.h"
 
 typedef struct {
-    float step_size;
+    CfgTargetFilter cfg;
+    float on_speed;
+    float off_speed;
 
-    float input;
-    float ramped_step_size;
-    SmoothTarget smooth_target;
-    EMAFilter ema_target;
+    float v1;
+    float step;
+    float value;
+} SmoothTarget;
 
-    float setpoint;
-} Remote;
+void smooth_target_configure(
+    SmoothTarget *st, const CfgTargetFilter *cfg, float on_speed, float off_speed, float hertz
+);
 
-void remote_init(Remote *remote);
+void smooth_target_reset(SmoothTarget *st, float value);
 
-void remote_reset(Remote *remote);
-
-void remote_configure(Remote *remote, const RefloatConfig *config);
-
-void remote_input(Remote *remote, const RefloatConfig *config);
-
-void remote_update(Remote *remote, const State *state, const RefloatConfig *config, float dt);
+void smooth_target_update(SmoothTarget *st, float target);

--- a/src/torque_tilt.c
+++ b/src/torque_tilt.c
@@ -69,10 +69,11 @@ static float calculate_torque_tilt_target(
         sign(motor->filt_current);
 
     float step_size = 0;
-    if ((tt->setpoint - tt->target > 0 && tt->target > 0) ||
-        (tt->setpoint - tt->target < 0 && tt->target < 0)) {
+    if ((tt->setpoint * tt->target >= 0) && (fabsf(tt->setpoint) > fabsf(tt->target))) {
+        // Moving towards smaller angle of same sign or zero
         step_size = tt->off_step_size;
     } else {
+        // Moving towards larger angle of same sign or crossing zero
         step_size = tt->on_step_size;
     }
 

--- a/src/torque_tilt.c
+++ b/src/torque_tilt.c
@@ -25,14 +25,33 @@
 void torque_tilt_reset(TorqueTilt *tt) {
     tt->setpoint = 0;
     tt->ramped_step_size = 0;
+
+    smooth_target_reset(&tt->smooth_target, 0.0f);
+    ema_filter_reset(&tt->ema_target, 0.0f, 0.0f);
 }
 
 void torque_tilt_configure(TorqueTilt *tt, const RefloatConfig *config) {
     tt->on_step_size = config->torquetilt_on_speed / config->hertz;
     tt->off_step_size = config->torquetilt_off_speed / config->hertz;
+
+    smooth_target_configure(
+        &tt->smooth_target,
+        &config->target_filter,
+        config->torquetilt_on_speed,
+        config->torquetilt_off_speed,
+        config->hertz
+    );
+    ema_filter_configure(
+        &tt->ema_target,
+        &config->target_filter,
+        config->torquetilt_on_speed,
+        config->torquetilt_off_speed
+    );
 }
 
-void torque_tilt_update(TorqueTilt *tt, const MotorData *motor, const RefloatConfig *config) {
+void torque_tilt_update(
+    TorqueTilt *tt, const MotorData *motor, const RefloatConfig *config, float dt
+) {
     float strength =
         motor->braking ? config->torquetilt_strength_regen : config->torquetilt_strength;
 
@@ -59,8 +78,18 @@ void torque_tilt_update(TorqueTilt *tt, const MotorData *motor, const RefloatCon
         step_size /= 2;
     }
 
-    // Smoothen changes in tilt angle by ramping the step size
-    smooth_rampf(&tt->setpoint, &tt->ramped_step_size, target, step_size, 0.04, 1.5);
+    if (config->target_filter.tt_type == SFT_NONE) {
+        rate_limitf(&tt->setpoint, target, step_size);
+    } else if (config->target_filter.tt_type == SFT_EMA3) {
+        ema_filter_update(&tt->ema_target, target, dt);
+        tt->setpoint = tt->ema_target.value;
+    } else if (config->target_filter.tt_type == SFT_THREE_STAGE) {
+        smooth_target_update(&tt->smooth_target, target);
+        tt->setpoint = tt->smooth_target.value;
+    } else {
+        // Smoothen changes in tilt angle by ramping the step size
+        smooth_rampf(&tt->setpoint, &tt->ramped_step_size, target, step_size, 0.04, 1.5);
+    }
 }
 
 void torque_tilt_winddown(TorqueTilt *tt) {

--- a/src/torque_tilt.h
+++ b/src/torque_tilt.h
@@ -28,6 +28,7 @@ typedef struct {
     float off_step_size;
     float ramped_step_size;
 
+    float target;
     float setpoint;
 
     SmoothTarget smooth_target;
@@ -39,7 +40,5 @@ void torque_tilt_reset(TorqueTilt *tt);
 void torque_tilt_configure(TorqueTilt *tt, const RefloatConfig *config);
 
 void torque_tilt_update(
-    TorqueTilt *tt, const MotorData *motor, const RefloatConfig *config, float dt
+    TorqueTilt *tt, const MotorData *motor, const RefloatConfig *config, bool wheelslip, float dt
 );
-
-void torque_tilt_winddown(TorqueTilt *tt);

--- a/src/torque_tilt.h
+++ b/src/torque_tilt.h
@@ -19,7 +19,9 @@
 #pragma once
 
 #include "conf/datatypes.h"
+#include "ema_filter.h"
 #include "motor_data.h"
+#include "smooth_target.h"
 
 typedef struct {
     float on_step_size;
@@ -27,12 +29,17 @@ typedef struct {
     float ramped_step_size;
 
     float setpoint;
+
+    SmoothTarget smooth_target;
+    EMAFilter ema_target;
 } TorqueTilt;
 
 void torque_tilt_reset(TorqueTilt *tt);
 
 void torque_tilt_configure(TorqueTilt *tt, const RefloatConfig *config);
 
-void torque_tilt_update(TorqueTilt *tt, const MotorData *motor, const RefloatConfig *config);
+void torque_tilt_update(
+    TorqueTilt *tt, const MotorData *motor, const RefloatConfig *config, float dt
+);
 
 void torque_tilt_winddown(TorqueTilt *tt);

--- a/src/utils.h
+++ b/src/utils.h
@@ -57,7 +57,7 @@
 #endif
 
 // Declaration for the SEMD_APP_DATA macro, definition needs to be in main.c.
-void send_app_data_overflow_terminate();
+void fatal_error_terminate();
 
 #define SEND_BUF_MAX_SIZE 511
 
@@ -77,7 +77,7 @@ void send_app_data_overflow_terminate();
                 ind                                                                                \
             );                                                                                     \
             /* terminate the main thread, the memory has just been corrupted by buffer overflow */ \
-            send_app_data_overflow_terminate();                                                    \
+            fatal_error_terminate();                                                               \
         }                                                                                          \
         VESC_IF->send_app_data(buffer, ind);                                                       \
     } while (0)

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-1.2.0-alpha
+1.2.0-testing


### PR DESCRIPTION
Fix: Tilt Release Speed (TT/ATR) is no longer used when crossing 0°;
 only used when moving towards smaller angle of same sign or 0°