### PR TITLE
Feature: Humidity Tiltback & Haptics

### DIFF
--- a/lisp/bms.lisp
+++ b/lisp/bms.lisp
@@ -10,6 +10,7 @@
             (var msg-age (get-bms-val 'bms-msg-age))
             (setq temp-max (get-bms-val 'bms-temp-cell-max))
             (setq temp-min temp-max)
+            (var hum (get-bms-val 'bms-hum))
 
             (if v-cell-support {
                 (if (= (get-bms-val 'bms-data-version) 1) {
@@ -30,7 +31,7 @@
                     })
                 })
             })
-            (ext-bms v-min v-max temp-min temp-max temp-fet msg-age)
+            (ext-bms v-min v-max temp-min temp-max temp-fet hum msg-age)
         })
         (sleep 0.2)
     })

--- a/src/bms.c
+++ b/src/bms.c
@@ -27,6 +27,7 @@ void bms_init(BMS *bms) {
     bms->cell_ht = 0;
     bms->bms_ht = 0;
     bms->msg_age = 42.0f;
+    bms->humidity = 0;
     bms->fault_mask = BMSF_NONE;
 }
 
@@ -34,7 +35,7 @@ static inline void set_fault(uint32_t *fault_mask, BMSFaultCode fault_code) {
     *fault_mask |= 1u << (fault_code - 1);
 }
 
-void bms_update(BMS *bms, const CfgBMS *cfg, const Time *time) {
+void bms_update(BMS *bms, const CfgBMS *cfg, const uint8_t tiltback_humidity, const Time *time) {
     if (!cfg->enabled) {
         bms->fault_mask = BMSF_NONE;
         return;
@@ -76,6 +77,10 @@ void bms_update(BMS *bms, const CfgBMS *cfg, const Time *time) {
 
     if (fabsf(bms->cell_lv - bms->cell_hv) > cfg->cell_balance_threshold) {
         set_fault(&fault_mask, BMSF_CELL_BALANCE);
+    }
+
+    if (tiltback_humidity > 0 && bms->humidity > 0 && bms->humidity >= tiltback_humidity) {
+        set_fault(&fault_mask, BMSF_HUMIDITY);
     }
 
     bms->fault_mask = fault_mask;

--- a/src/bms.h
+++ b/src/bms.h
@@ -32,7 +32,8 @@ typedef enum {
     BMSF_CELL_UNDER_VOLTAGE = 4,
     BMSF_CELL_OVER_TEMP = 5,
     BMSF_CELL_UNDER_TEMP = 6,
-    BMSF_CELL_BALANCE = 7
+    BMSF_CELL_BALANCE = 7,
+    BMSF_HUMIDITY = 8
 } BMSFaultCode;
 
 typedef struct {
@@ -41,6 +42,7 @@ typedef struct {
     int16_t cell_lt;
     int16_t cell_ht;
     int16_t bms_ht;
+    uint8_t humidity;
     float msg_age;
 
     uint32_t fault_mask;
@@ -48,6 +50,6 @@ typedef struct {
 
 void bms_init(BMS *bms);
 
-void bms_update(BMS *bms, const CfgBMS *cfg, const Time *time);
+void bms_update(BMS *bms, const CfgBMS *cfg, const uint8_t tiltback_humidity, const Time *time);
 
 bool bms_is_fault(const BMS *bms, BMSFaultCode fault_code);

--- a/src/conf/datatypes.h
+++ b/src/conf/datatypes.h
@@ -247,6 +247,7 @@ typedef struct {
     float tiltback_lv_angle;
     float tiltback_lv_speed;
     float tiltback_lv;
+    uint8_t tiltback_humidity;
     float tiltback_return_speed;
     float tiltback_constant;
     uint16_t tiltback_constant_erpm;

--- a/src/conf/settings.xml
+++ b/src/conf/settings.xml
@@ -922,6 +922,26 @@ p, li { white-space: pre-wrap; }
             <suffix> V</suffix>
             <vTx>7</vTx>
         </tiltback_lv>
+        <tiltback_humidity>
+            <longName>High Humidity Threshold</longName>
+            <type>2</type>
+            <transmittable>1</transmittable>
+            <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;High Humidity threshold to trigger a safety pushback (Pushback raises the nose of the vehicle informing you to slow down).&lt;br /&gt;&lt;br /&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Recommended Value: &amp;gt; 65% warning. &amp;gt; 80% danger&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+            <cDefine>CFG_DFLT_TILTBACK_HUMIDITY</cDefine>
+            <editorScale>1</editorScale>
+            <editAsPercentage>0</editAsPercentage>
+            <maxInt>100</maxInt>
+            <minInt>0</minInt>
+            <showDisplay>0</showDisplay>
+            <stepInt>1</stepInt>
+            <valInt>65</valInt>
+            <suffix> %</suffix>
+            <vTx>1</vTx>
+        </tiltback_humidity>
         <tiltback_return_speed>
             <longName>Return To Level Speed</longName>
             <type>1</type>
@@ -4062,6 +4082,7 @@ p, li { white-space: pre-wrap; }
         <ser>tiltback_lv_angle</ser>
         <ser>tiltback_lv_speed</ser>
         <ser>tiltback_lv</ser>
+        <ser>tiltback_humidity</ser>
         <ser>tiltback_return_speed</ser>
         <ser>tiltback_constant</ser>
         <ser>tiltback_constant_erpm</ser>
@@ -4323,6 +4344,7 @@ p, li { white-space: pre-wrap; }
                 <subgroupParams>
                     <param>::sep::General Config</param>
                     <param>tiltback_return_speed</param>
+                    <param>tiltback_humidity</param>
                     <param>::sep::Duty Cycle Alert Pushback</param>
                     <param>tiltback_duty</param>
                     <param>tiltback_duty_angle</param>

--- a/src/data.h
+++ b/src/data.h
@@ -84,6 +84,7 @@ typedef struct {
     float tiltback_variable, tiltback_variable_max_erpm, noseangling_step_size;
     float mc_max_temp_fet, mc_max_temp_mot;
     bool duty_beeping;
+    uint8_t humidity;
 
     // IMU data for the balancing filter
     BalanceFilterData balance_filter;

--- a/ui.qml.in
+++ b/ui.qml.in
@@ -129,6 +129,7 @@ Item {
                 commands.sendGetRtDataIds();
             } else {
                 commands.sendGetRtData();
+                commands.sendHumidity();
             }
 
             if (moveSlider.value != 0) {
@@ -595,6 +596,7 @@ Item {
         readonly property int c_DATA_RECORD_REQUEST: 41
         readonly property int c_DATA_RECORD_HEADER: 42
         readonly property int c_DATA_RECORD_DATA: 43
+        readonly property int c_HUMIDITY: 51
 
         // IEEE-754 16-bit floating-point format (without infinity and NaNs)
         // Dynamic range: +-131008.0
@@ -651,6 +653,10 @@ Item {
 
         function sendGetRtData() {
             vescCommands.sendCustomAppData(createData(2, c_REALTIME_DATA).buffer);
+        }
+
+        function sendHumidity() {
+            vescCommands.sendCustomAppData(createData(2, c_HUMIDITY).buffer);
         }
 
         function sendGetRtDataIds() {
@@ -865,6 +871,9 @@ Item {
                 recordedPlotData.receiveHeader(dv, ind);
             } else if (msgtype === c_DATA_RECORD_DATA) {
                 recordedPlotData.receiveData(dv, ind);
+            } else if (msgtype === c_HUMIDITY) {
+                state.humidity = dv.getUint8(ind++);
+                state.bmsHumidity = dv.getUint8(ind++);
             }
 
             packageConnectionWatchdog.restart();
@@ -1399,6 +1408,8 @@ Item {
             [15, "BMS: Cell Balance"],
             [16, "BMS: Connection Error"],
             [17, "BMS: BMS Temp"],
+            [18, "BMS: BMS Humidity"],
+            [19, "Controller Humidity"],
         ])
 
         property int beepReason: 0
@@ -1415,6 +1426,9 @@ Item {
 
         property string errorText: ""
         property string errorDescription: ""
+
+        property int humidity: 0
+        property int bmsHumidity: 0
 
         function updateErrorStrings() {
             if (!!vescFault) {
@@ -6282,6 +6296,9 @@ Item {
 
                         Value {id: debugStopReason; label: "Stop Condition"; value: state.stopConditionString}
                         Value {id: debugLastBeepReason; label: "Last Beep Reason"; value: state.beepReasonString}
+                        Value {id: debugHumidity; label: "Controller Humidity"; value: (state.humidity>0 ? state.humidity.toString() + "%" : "")}
+                        Value {id: debugBmsHumidity; label: "BMS Humidity"; value: (state.bmsHumidity>0 ? state.bmsHumidity.toString() + "%" : "")}
+
 
                         Item {
                             width: parent.width


### PR DESCRIPTION
Add support for pushback alerts based on humidity sensor readings from battery and controller boxes.

For the bms humidity reading this can be just grabbed from lisp. For the controller, there isn't really any official support for a humidity sensor, so I added a new command "COMMAND_HUMIDITY" value of 51. When no arguments are passed it returns two bytes for the controller humidity sensor and the bms humidity sensor. These are now displayed in the data section of appui under beep reason. When one argument is passed, it will take that byte and assign it to the humidity variable for the controller. 

The tiltback will only be triggered if either of the humidities are above 0% (i.e. initialized) and the new config setting tiltback_humidity_threshold > 0%.