### PR TITLE
Correct UI typo in settings.xml

### DIFF
--- a/src/conf/settings.xml
+++ b/src/conf/settings.xml
@@ -1880,7 +1880,7 @@ p, li { white-space: pre-wrap; }
             <vTx>7</vTx>
         </torquetilt_start_current>
         <torquetilt_angle_limit>
-            <longName>Tilitback Angle Limit</longName>
+            <longName>Tiltback Angle Limit</longName>
             <type>1</type>
             <transmittable>1</transmittable>
             <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -2121,7 +2121,7 @@ p, li { white-space: pre-wrap; }
             <vTx>7</vTx>
         </atr_speed_boost>
         <atr_angle_limit>
-            <longName>Tilitback Angle Limit</longName>
+            <longName>Tiltback Angle Limit</longName>
             <type>1</type>
             <transmittable>1</transmittable>
             <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -2383,7 +2383,7 @@ p, li { white-space: pre-wrap; }
             <vTx>7</vTx>
         </turntilt_strength>
         <turntilt_angle_limit>
-            <longName>Tilitback Angle Limit</longName>
+            <longName>Tiltback Angle Limit</longName>
             <type>1</type>
             <transmittable>1</transmittable>
             <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;


### PR DESCRIPTION
Fix three instances of a recurring minor typo that appears in the UI.  "Tilitback" should be "Tiltback".