### PR TITLE
Fixed logic for tilt/release speed conditions (for v1.2)

### DIFF
--- a/src/torque_tilt.c
+++ b/src/torque_tilt.c
@@ -55,9 +55,15 @@ void torque_tilt_update(TorqueTilt *tt, const MotorData *motor, const RefloatCon
         sign(motor->filt_current);
 
     float step_size = 0;
-    if ((tt->setpoint - target > 0 && target > 0) || (tt->setpoint - target < 0 && target < 0)) {
+    if (tt->setpoint * target < 0) {
+        // Moving towards opposite sign (crossing zero);
+        // Use the faster tilt speed until 0 is reached
+        step_size = fmaxf(tt->off_step_size, tt->on_step_size);
+    } else if (fabsf(tt->setpoint) > fabsf(target)) {
+        // Moving towards smaller angle of same sign or zero
         step_size = tt->off_step_size;
     } else {
+        // Moving towards larger angle of same sign
         step_size = tt->on_step_size;
     }
 


### PR DESCRIPTION
Fix: Fixed Torque Tilt tilt/release speed conditions:
 - Release Speed now used when TT is targeting 0° (was previously incorrectly using Tilt Speed when returning to exactly 0°)
 - Fastest tilt speed (between Tilt and Release Speeds) now used when crossing 0°

