### PR TITLE
Implemented 3-Stage Smoothing for Remote Tilt (Hardcoded)

### DIFF
--- a/src/conf/datatypes.h
+++ b/src/conf/datatypes.h
@@ -200,6 +200,12 @@ typedef struct {
 } CfgBMS;
 
 typedef struct {
+    float alpha;
+    float in_alpha_away;
+    float in_alpha_back;
+} CfgTargetFilter;
+
+typedef struct {
     bool is_default;
 } CfgMeta;
 

--- a/src/data.h
+++ b/src/data.h
@@ -104,6 +104,7 @@ typedef struct {
     float noseangling_interpolated;
     time_t alert_timer;
     time_t nag_timer;
+    float dt;
     float idle_voltage;
     time_t fault_angle_pitch_timer, fault_angle_roll_timer, fault_switch_timer,
         fault_switch_half_timer;

--- a/src/main.c
+++ b/src/main.c
@@ -186,6 +186,8 @@ static void configure(Data *d) {
 
     lcm_configure(&d->lcm, &d->float_conf.leds);
 
+    d->dt = 1.0f / d->float_conf.hertz;
+
     // Loop time in microseconds
     d->loop_time_us = 1e6 / d->float_conf.hertz;
 
@@ -874,7 +876,7 @@ static void refloat_thd(void *arg) {
             );
             d->setpoint = d->setpoint_target_interpolated;
 
-            remote_update(&d->remote, &d->state, &d->float_conf);
+            remote_update(&d->remote, &d->state, &d->float_conf, d->dt);
             d->setpoint += d->remote.setpoint;
 
             if (!d->state.darkride) {

--- a/src/smooth_target.c
+++ b/src/smooth_target.c
@@ -1,0 +1,61 @@
+// Copyright 2024 Lukas Hrazky
+//
+// This file is part of the Refloat VESC package.
+//
+// Refloat VESC package is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Refloat VESC package is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program. If not, see <http://www.gnu.org/licenses/>.
+
+#include "smooth_target.h"
+
+#include "utils.h"
+
+#include <math.h>
+
+void smooth_target_configure(
+    SmoothTarget *st, const CfgTargetFilter *cfg, float on_speed, float off_speed, float hertz
+) {
+    st->cfg = *cfg;
+    st->on_speed = on_speed / hertz;
+    st->off_speed = off_speed / hertz;
+}
+
+void smooth_target_reset(SmoothTarget *st, float value) {
+    st->v1 = 0;
+    st->step = 0;
+    st->value = value;
+}
+
+void smooth_target_update(SmoothTarget *st, float target) {
+    st->v1 += st->cfg.alpha * (target - st->v1);
+
+    float delta = st->cfg.alpha * (st->v1 - st->value);
+
+    if (fabsf(delta) > fabsf(st->step) || sign(delta) != sign(st->step)) {
+        if (sign(st->value) == sign(delta)) {
+            st->step += st->cfg.in_alpha_away * (delta - st->step);
+        } else {
+            st->step += st->cfg.in_alpha_back * (delta - st->step);
+        }
+    } else {
+        st->step = delta;
+    }
+
+    float speed_limit;
+    if (sign(st->step) == sign(st->value)) {
+        speed_limit = st->on_speed;
+    } else {
+        speed_limit = st->off_speed;
+    }
+
+    st->value += sign(st->step) * min(fabsf(st->step), speed_limit);
+}

--- a/src/smooth_target.h
+++ b/src/smooth_target.h
@@ -1,4 +1,4 @@
-// Copyright 2025 Lukas Hrazky
+// Copyright 2024 Lukas Hrazky
 //
 // This file is part of the Refloat VESC package.
 //
@@ -18,25 +18,21 @@
 #pragma once
 
 #include "conf/datatypes.h"
-#include "smooth_target.h"
-#include "state.h"
 
 typedef struct {
-    float step_size;
+    CfgTargetFilter cfg;
+    float on_speed;
+    float off_speed;
 
-    float input;
-    float ramped_step_size;
-    SmoothTarget smooth_target;
+    float v1;
+    float step;
+    float value;
+} SmoothTarget;
 
-    float setpoint;
-} Remote;
+void smooth_target_configure(
+    SmoothTarget *st, const CfgTargetFilter *cfg, float on_speed, float off_speed, float hertz
+);
 
-void remote_init(Remote *remote);
+void smooth_target_reset(SmoothTarget *st, float value);
 
-void remote_reset(Remote *remote);
-
-void remote_configure(Remote *remote, const RefloatConfig *config);
-
-void remote_input(Remote *remote, const RefloatConfig *config);
-
-void remote_update(Remote *remote, const State *state, const RefloatConfig *config, float dt);
+void smooth_target_update(SmoothTarget *st, float target);


### PR DESCRIPTION
Feature: Added 3-Stage Smoothing for Remote Tilt;
 Parameters are hard-coded to serve remotes well

This is a lower priority one that I can definitely understand if you'd like to hold off on. I just know with the high tilt speeds I use for remotes, the smoother 3-Stage smoothing has been immensely appreciated in smoothing out the response, the difference is definitely felt. This is hard coded with values that work well for me and have a similar response as the previous smoothing, just more refined. Tested to work well at all tilt speeds. No parameters added here.

I really just did it for myself since I've gotten spoiled by it, but wanted to throw in in case you had any interest in including the improvement.