### PR TITLE
Reworked ATR Tilt Speed conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: cachix/install-nix-action@v25
       - uses: rrbutani/use-nix-shell-action@v1
         with:
-          flakes: nixpkgs#clang-tools_18, nixpkgs#lefthook
+          flakes: nixpkgs#llvmPackages_18.clang-tools, nixpkgs#lefthook
 
       - name: Run clang-format
         id: clang-format

--- a/src/atr.h
+++ b/src/atr.h
@@ -25,6 +25,8 @@ typedef struct {
     float on_step_size;
     float off_step_size;
     float speed_boost_mult;
+    float tt_boost_uphill_margin;
+    float tt_boost_downhill_threshold;
 
     float accel_diff;
     float speed_boost;


### PR DESCRIPTION
Fix: Reworked ATR Tilt Speed conditions:
 - Re-organized implementation to avoid repeated logic
 - Accounts for ATR Thresholds in the Boost margin
 - Uses "On" Tilt Speed for Transition Boost if faster

The margins originally in place to determine whether or not to use Transition Boost were before ATR Thresholds, when ATR Setpoint would constantly jump around between positive and negative when cruising. With these thresholds in place, the margins are less necessary and achieve the same effect. This fix negates the thresholds from the margins in effect, making the response the same as originally intended (unless the thresholds are larger than the original margins, then those are respected).

Additionally, depending on configuration and your current speed, there can be situations where Tilt Speed * the current Response Boost is faster than the Transition Boost speed. So for transition boost, we look at both tilt speeds and use the fastest one available, similarly to how transitions are now handled in Torque Tiltback in my other Pull Request.

The logic was also just reorganized as a whole, the original structure had unnecessary repeating logic and was slightly hard to follow. It's still a lot here thanks to the new logic, but I consolidated what I can.