### PR TITLE
Fix TurnTilt & NoseAngling handling in Wheelslip

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -881,13 +881,12 @@ static void refloat_thd(void *arg) {
                 // in case of wheelslip, don't change torque tilts, instead slightly decrease each
                 // cycle
                 if (d->state.wheelslip) {
+                    turn_tilt_winddown(&d->turn_tilt);
                     torque_tilt_winddown(&d->torque_tilt);
                     atr_winddown(&d->atr);
                     brake_tilt_winddown(&d->brake_tilt);
                 } else {
                     apply_noseangling(d);
-                    d->setpoint += d->noseangling_interpolated;
-
                     turn_tilt_update(
                         &d->turn_tilt,
                         &d->motor,
@@ -896,7 +895,6 @@ static void refloat_thd(void *arg) {
                         d->noseangling_interpolated,
                         &d->float_conf
                     );
-                    d->setpoint += d->turn_tilt.setpoint;
 
                     torque_tilt_update(&d->torque_tilt, &d->motor, &d->float_conf);
                     atr_update(&d->atr, &d->motor, &d->float_conf);
@@ -908,6 +906,9 @@ static void refloat_thd(void *arg) {
                         d->setpoint - d->imu.balance_pitch
                     );
                 }
+
+                d->setpoint += d->noseangling_interpolated;
+                d->setpoint += d->turn_tilt.setpoint;
 
                 // aggregated torque tilts:
                 // if signs match between torque tilt and ATR + brake tilt, use the more significant

--- a/src/turn_tilt.c
+++ b/src/turn_tilt.c
@@ -156,3 +156,7 @@ void turn_tilt_update(
     // Smoothen changes in tilt angle by ramping the step size
     smooth_rampf(&tt->setpoint, &tt->ramped_step_size, tt->target, tt->step_size, 0.04, 1.5);
 }
+
+void turn_tilt_winddown(TurnTilt *tt) {
+    tt->setpoint *= 0.995;
+}

--- a/src/turn_tilt.h
+++ b/src/turn_tilt.h
@@ -53,3 +53,5 @@ void turn_tilt_update(
     float noseangling,
     const RefloatConfig *config
 );
+
+void turn_tilt_winddown(TurnTilt *tt);


### PR DESCRIPTION
Fix: TurnTilt & NoseAngling handling in Wheelslip
  - Setpoints are now still applied during wheelslip, fixing the sudden setpoint change from previous, which could cause jarring changes in requested current
  - TurnTilt is now wound down (instead of frozen) during Wheelslip