### PR TITLE
Fix unintended extra short beep on package start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ all: refloat.vescpkg
 
 refloat.vescpkg: src lisp/package.lisp package_README-gen.md ui.qml
 ifeq ($(OLDVT), 1)
-	$(VESC_TOOL) --buildPkg "refloat.vescpkg:lisp/package.lisp:ui.qml:0:package_README-gen.md:Refloat"
+	"$(VESC_TOOL)" --buildPkg "refloat.vescpkg:lisp/package.lisp:ui.qml:0:package_README-gen.md:Refloat"
 else
-	$(VESC_TOOL) --buildPkgFromDesc pkgdesc.qml
+	"$(VESC_TOOL)" --buildPkgFromDesc pkgdesc.qml
 endif
 
 src:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ If you don't have `vesc_tool` in your `$PATH` (but you have, for example, a down
 ```sh
 make VESC_TOOL=/path/to/vesc_tool
 ```
+For macOS, the path to VESC Tool when installed using the official installer is as follows:
+```sh
+make VESC_TOOL="/Applications/VESC Tool.app/Contents/MacOS/VESC Tool"
+```
 
 ## Documentation
 [Development Documentation](doc/index.md)

--- a/src/main.c
+++ b/src/main.c
@@ -103,6 +103,7 @@ const VESC_PIN beeper_pin = VESC_PIN_PPM;
 
 void beeper_init() {
     VESC_IF->io_set_mode(beeper_pin, VESC_PIN_MODE_OUTPUT);
+    VESC_IF->io_write(beeper_pin, 0);
 }
 
 void beeper_update(Data *d) {
@@ -1232,6 +1233,10 @@ static void data_init(Data *d) {
     );
 
     d->odometer = VESC_IF->mc_get_odometer();
+
+    d->beep_num_left = 0;
+    d->beep_duration = 0;
+    d->beep_countdown = 0;
 }
 
 // See also:


### PR DESCRIPTION
While using beeper on servo (PPM) pin I noticed that my board makes 2 short beeps and 1 long beep on startup.
And knowing this [On boot: short beep when VESC boots, long beep when balance app is ready (and each time you write app config!) or triple-beep when float package is disabled](https://pev.dev/t/buzzer-for-float-package/99) from Float package article by surfdado (IFAIK beeper code was unchanged in refloat) it made me think that 1 extra short beep is due to some errors/faults.
According to current implementation correct behaviour indeed should be 1 short beep (in `configure()`) and 1 long beep (when board is ready).
1 short beep (in `configure()`):
https://github.com/lukash/refloat/blob/a86a3eb3c64a3672bca154c6f03922f5b218750b/src/main.c#L227
1 long beep (when board is ready)
https://github.com/lukash/refloat/blob/a86a3eb3c64a3672bca154c6f03922f5b218750b/src/main.c#L847-L848

That one extra short beep happens unintentionally due to beeper_pin having high level right after pin init here:
https://github.com/lukash/refloat/blob/a86a3eb3c64a3672bca154c6f03922f5b218750b/src/main.c#L105
And since `beeper_update` waits for `beep_countdown` to be 0 and does nothing to the pin after `beep_alert()` the pin remains high for that first beep_countdown period which makes that beep.

Also I wanted to try to build the package on MacOS which was successful but since vesc_tool path in MacOS contains spaces I had to wrap `$(VESC_TOOL)` in double quotes in Makefile. I double checked this change on Linux and it is not causing any issues.