### PR TITLE
Remove footpads disabling LEDs on startup

### DIFF
--- a/src/conf/settings.xml
+++ b/src/conf/settings.xml
@@ -3591,8 +3591,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The rest of the options is ignored for the &lt;span style=&quot; font-style:italic;&quot;&gt;External&lt;/span&gt; LED type.&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Board restart required for changes to take effect.&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Note: Pressing both footpad sensors when turning on the board will disable the LED initialization. Use if the LEDs break your VESC in a way that prevents you to connect and change configuration (e.g. due to an overcurrent).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
             <cDefine>CFG_DFLT_HARDWARE_LED_MODE</cDefine>
             <valInt>0</valInt>
             <enumNames>Off</enumNames>

--- a/src/leds.c
+++ b/src/leds.c
@@ -792,7 +792,7 @@ void leds_init(Leds *leds) {
     led_driver_init(&leds->led_driver);
 }
 
-void leds_setup(Leds *leds, CfgHwLeds *hw_cfg, const CfgLeds *cfg, FootpadSensorState fs_state) {
+void leds_setup(Leds *leds, CfgHwLeds *hw_cfg, const CfgLeds *cfg) {
     uint8_t status_offset = 0;
     uint8_t front_offset = 0;
     uint8_t rear_offset = 0;
@@ -823,9 +823,7 @@ void leds_setup(Leds *leds, CfgHwLeds *hw_cfg, const CfgLeds *cfg, FootpadSensor
         leds->status_strip.length + leds->front_strip.length + leds->rear_strip.length;
 
     uint32_t *led_data = NULL;
-    if (fs_state == FS_BOTH) {
-        log_msg("Both sensors pressed, not initializing LEDs.");
-    } else if (leds->front_strip.length + leds->rear_strip.length > LEDS_FRONT_AND_REAR_COUNT_MAX) {
+    if (leds->front_strip.length + leds->rear_strip.length > LEDS_FRONT_AND_REAR_COUNT_MAX) {
         log_error("Front and rear LED counts exceed maximum.");
     } else if (hw_cfg->mode & LED_MODE_INTERNAL && led_count > 0) {
         led_data = VESC_IF->malloc(sizeof(uint32_t) * led_count);

--- a/src/leds.h
+++ b/src/leds.h
@@ -82,7 +82,7 @@ typedef struct {
 
 void leds_init(Leds *leds);
 
-void leds_setup(Leds *leds, CfgHwLeds *hw_cfg, const CfgLeds *cfg, FootpadSensorState fs_state);
+void leds_setup(Leds *leds, CfgHwLeds *hw_cfg, const CfgLeds *cfg);
 
 void leds_configure(Leds *leds, const CfgLeds *cfg);
 

--- a/src/main.c
+++ b/src/main.c
@@ -2455,7 +2455,7 @@ INIT_FUN(lib_info *info) {
     }
 
     footpad_sensor_update(&d->footpad, &d->float_conf);
-    leds_setup(&d->leds, &d->float_conf.hardware.leds, &d->float_conf.leds, d->footpad.state);
+    leds_setup(&d->leds, &d->float_conf.hardware.leds, &d->float_conf.leds);
 
     VESC_IF->imu_set_read_callback(imu_ref_callback);
     VESC_IF->conf_custom_add_config(get_cfg, set_cfg, get_cfg_xml);


### PR DESCRIPTION
Remove the disabling of LEDs if both sensors are pressed during startup. Settings.xml LED Mode description is updated to reflect the change