### PR TITLE
Fix disappearing last beep reason

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1336,7 +1336,6 @@ static void cmd_send_all_data(Data *d, unsigned char mode) {
             state |= 0x8;
         }
         buffer[ind++] = (state & 0xF) + (d->beep_reason << 4);
-        d->beep_reason = BEEP_NONE;
 
         buffer[ind++] = d->footpad.adc1 * 50;
         buffer[ind++] = d->footpad.adc2 * 50;


### PR DESCRIPTION
Fix: Stop the "last beep reason" text from disappearing once the beep condition stops

Got this fix finalized. I was also thinking the "sensor stop condition" and "last beep reason" texts should always be visible to let the users know that they're able to see that data if it's applicable.