### PR TITLE
Add Nix support for building refloat, and use it in CI/CD

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -13,10 +13,7 @@ runs:
       with:
         name: refloat
         authToken: '${{ inputs.cache-auth-token }}'
-    - uses: rrbutani/use-nix-shell-action@v1
-      with:
-        flakes: nixpkgs/nixos-24.11#gcc-arm-embedded-13, nixpkgs#gnumake, github:lukash/vesc_tool-flake/release_6_06
 
     - name: Build
       shell: bash
-      run: make -j
+      run: nix build .#refloat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: rrbutani/use-nix-shell-action@v1
         with:
           flakes: nixpkgs#llvmPackages_18.clang-tools, nixpkgs#pre-commit
+          extraNixOptions: --inputs-from .
 
       - name: Run clang-format
         id: clang-format

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -51,13 +51,11 @@ jobs:
         with:
           cache-auth-token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - name: Extract Config Signature
-        run: cat src/conf/confparser.h | sed -n 's/^#define .\+_SIGNATURE\W\+\([0-9]*\)/\1/p' > config_signature.txt
-
       - name: Rename Package File
         run: |
-          mv refloat.vescpkg refloat-${{env.VERSION}}.vescpkg
-          mv src/package_lib.elf refloat-${{env.VERSION}}.elf
+          cp result/refloat.vescpkg refloat-${{env.VERSION}}.vescpkg
+          cp result/refloat.elf refloat-${{env.VERSION}}.elf
+          cp result/config_signature.txt config_signature.txt
 
       - name: Install Changelog Generation Dependencies
         run: sudo apt-get install python3-git

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ ui.qml
 *.obj
 *.so
 *.vescpkg
+
+/result

--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,16 @@ else
     MINIFY_CMD="cat"
 endif
 
+BUILD_DATE=`date --rfc-3339=seconds`
+GIT_HASH=`git rev-parse --short HEAD`
+
 package_README-gen.md: package_README.md version
 	cp $< $@
 	echo "" >> $@
 	echo "### Build Info" >> $@
 	echo "- Version: ${VERSION}" >> $@
-	echo "- Build Date: `date --rfc-3339=seconds`" >> $@
-	echo "- Git Commit: #`git rev-parse --short HEAD`" >> $@
+	echo "- Build Date: ${BUILD_DATE}" >> $@
+	echo "- Git Commit: #${GIT_HASH}" >> $@
 
 ui.qml: ui.qml.in package_name version
 	cat $< | \

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,187 @@
+{
+  "nodes": {
+    "bldcSrc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733324381,
+        "narHash": "sha256-ui9N8QSog1G5zyK7yRrD0Xl+Y2CZhvvhBkaJuQZ2qZw=",
+        "owner": "vedderb",
+        "repo": "bldc",
+        "rev": "a0d40e2c5a42c810888d8c379307e6b0a118a125",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vedderb",
+        "ref": "release_6_05",
+        "repo": "bldc",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778003029,
+        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgsOld": {
+      "locked": {
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1735554305,
+        "narHash": "sha256-zExSA1i/b+1NMRhGGLtNfFGXgLtgo+dcuzHzaWA6w3Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0e82ab234249d8eee3e8c91437802b32c74bb3fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "vesc-tool": "vesc-tool"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1744961264,
+        "narHash": "sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "8d404a69efe76146368885110f29a2ca3700bee6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "vesc-tool": {
+      "inputs": {
+        "bldcSrc": "bldcSrc",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgsOld": "nixpkgsOld",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1761839474,
+        "narHash": "sha256-1T3r7D6gQw+IuYHA+YANLd4/MfSKZ+Yqf21O1j0eLj8=",
+        "owner": "vedderb",
+        "repo": "vesc_tool",
+        "rev": "87689d9f69c2ffd5325224151a1f5124c93dd645",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vedderb",
+        "ref": "release_6_06",
+        "repo": "vesc_tool",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    vesc-tool.url = "github:vedderb/vesc_tool/release_6_06";
+    vesc-tool.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = {
+    self,
+    flake-utils,
+    nixpkgs,
+    vesc-tool,
+  } @ inputs:
+    flake-utils.lib.eachSystem ["x86_64-linux"] (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (final: prev: {
+              vesc-tool = vesc-tool.packages.${system}.vesc-tool;
+            })
+            (import ./nix/overlay.nix)
+            (final: prev: {
+              refloat = prev.refloat.overrideDerivation (old: {
+                version = prev.lib.strings.removeSuffix "\n" (builtins.readFile ./version);
+                src = self;
+
+                makeFlags = [
+                  "GIT_HASH=${builtins.substring 0 8 (self.rev or self.dirtyRev)}"
+                  "BUILD_DATE=${self.lastModifiedDate}"
+                ];
+              });
+            })
+          ];
+        };
+      in {
+        packages =
+          pkgs
+          // {
+            default = pkgs.refloat;
+          };
+      }
+    );
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,5 @@
+final: prev: {
+  refloat = final.callPackage ./refloat.nix {
+    gcc-arm-embedded = final.gcc-arm-embedded-13;
+  };
+}

--- a/nix/refloat.nix
+++ b/nix/refloat.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenv,
+  gcc-arm-embedded,
+  vesc-tool,
+  python3,
+}:
+stdenv.mkDerivation {
+  pname = "refloat";
+  version = "0.0.0-dev";
+
+  src = ../.;
+
+  postPatch = ''
+    # Python shebang is failing for some reason. Replace it with full shebang
+    sed -i '1s,.*,#!${lib.getExe python3},' rjsmin.py
+    echo "$version" > ./version
+  '';
+
+  doFixup = false;
+
+  nativeBuildInputs = [
+    gcc-arm-embedded
+    vesc-tool
+    python3
+  ];
+
+  installPhase = ''
+    mkdir $out
+    cp src/package_lib.elf $out/refloat.elf
+    cp refloat.vescpkg $out
+    cat src/conf/confparser.h | sed -n 's/^#define .\+_SIGNATURE\W\+\([0-9]*\)/\1/p' > $out/config_signature.txt
+  '';
+}


### PR DESCRIPTION
Add Nix support for building refloat, and use it in CI/CD.

Nix builds of Refloat should be binary reproducible allowing auditing of CI/CD flows.

Notes for review:
- vesc-tool is pinned at `release_6_06`
- ~~nixpkgs is pinned at the lock-file value from vesc-tool@`release_6_06`~~
  - nixpkgs is now tracking `nixos/25.11`. The exact revision is whatever is latest on that branch at the time of my commit.
- `nix/refloat.nix` can be built standalone, but will likely need a `src` override and/or `GIT_HASH` override. `flake.nix` does this automatically.
- `gcc-arm-embedded` is pinned at `13` by `overlay.nix`. This resolves to `13.3.rel1`.
- Only `refloat.elf` and `refloat.vescpkg` are supported as outputs.
- Only `x86_64-linux` is supported because VESC Tool only supports `x86_64`.
- Updating any dependency version now requires updating `flake.lock` via nix.

I've included a full migration to Nix in this MR, but am happy to drop commits if this feels like an overreach. I personally want nix support to be able to develop this locally.

I have tested creating a release with this GitHub action in my own repo. It did not actually create a release, but I think that's a configuration issue for my Fork repo. There were no errors displayed when creating the release.
https://github.com/MilesBreslin/refloat/actions/runs/24614823553