### PR TITLE
Added motor and current saturation to the led status bar

### DIFF
--- a/src/conf/datatypes.h
+++ b/src/conf/datatypes.h
@@ -130,7 +130,7 @@ typedef struct {
 
 typedef struct {
     uint16_t idle_timeout;
-    float duty_threshold;
+    float motor_utilization_threshold;
     float red_bar_percentage;
     bool show_sensors_while_running;
     float brightness_headlights_on;

--- a/src/conf/settings.xml
+++ b/src/conf/settings.xml
@@ -3294,32 +3294,34 @@ p, li { white-space: pre-wrap; }
             <cDefine>CFG_DFLT_LEDS_STATUS_SHOW_SENSORS_WHILE_RUNNING</cDefine>
             <valInt>1</valInt>
         </leds.status.show_sensors_while_running>
-        <leds.status.duty_threshold>
-            <longName>Status Duty Threshold</longName>
+        <leds.status.motor_utilization_threshold>
+            <longName>Motor Utilization Threshold</longName>
             <type>1</type>
             <transmittable>1</transmittable>
             <description>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Roboto'; ; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Duty threshold above which the duty is shown on the status bar (in amber yellow color) instead of the battery. Note there is a 10% hysteresis, meaning if you duty shows at 20%, it will be shown until it drops below 10% (to avoid constant blinking). Values below 15% set the threshold to 15%.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Threshold above which motor utilization is shown on the status bar (instead of the battery). Motor utilization is the maximum of duty cycle, motor current saturation, and battery current saturation. Note there is a 10% hysteresis, meaning if motor utilization shows at 60%, it will keep showing until it drops below 50% (to avoid constant blinking).&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Set to 0 to not show the duty bar.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The colors are as follows:&lt;br /&gt;Duty cycle: amber&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Motor current: pink&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Battery current: teal&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Note: Since duty above 95% is not achievable and you're unlikely to ever benefit from values above 90% being shown on your status bar, duty level of 90% is scaled to 100% on the status bar to make full use of its real estate.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</description>
-            <cDefine>CFG_DFLT_HARDWARE_LEDS_STATUS_DUTY_THRESHOLD</cDefine>
+            <cDefine>CFG_DFLT_HARDWARE_LEDS_STATUS_MOTOR_UTILIZATION_THRESHOLD</cDefine>
             <editorDecimalsDouble>0</editorDecimalsDouble>
             <editorScale>100</editorScale>
             <editAsPercentage>0</editAsPercentage>
             <maxDouble>1</maxDouble>
-            <minDouble>0</minDouble>
+            <minDouble>0.15</minDouble>
             <showDisplay>0</showDisplay>
             <stepDouble>5</stepDouble>
-            <valDouble>0.5</valDouble>
+            <valDouble>0.6</valDouble>
             <vTxDoubleScale>10000</vTxDoubleScale>
             <suffix>%</suffix>
             <vTx>7</vTx>
-        </leds.status.duty_threshold>
+        </leds.status.motor_utilization_threshold>
         <leds.status.red_bar_percentage>
             <longName>Red Color Bar Percentage</longName>
             <type>1</type>
@@ -4007,7 +4009,7 @@ p, li { white-space: pre-wrap; }
         <ser>leds.status.brightness_headlights_off</ser>
         <ser>leds.status.brightness_headlights_on</ser>
         <ser>leds.status.show_sensors_while_running</ser>
-        <ser>leds.status.duty_threshold</ser>
+        <ser>leds.status.motor_utilization_threshold</ser>
         <ser>leds.status.red_bar_percentage</ser>
         <ser>leds.status.idle_timeout</ser>
         <ser>leds.status_idle.mode</ser>
@@ -4259,7 +4261,7 @@ p, li { white-space: pre-wrap; }
                     <param>leds.status.brightness_headlights_off</param>
                     <param>leds.status.brightness_headlights_on</param>
                     <param>leds.status.show_sensors_while_running</param>
-                    <param>leds.status.duty_threshold</param>
+                    <param>leds.status.motor_utilization_threshold</param>
                     <param>leds.status.red_bar_percentage</param>
                     <param>leds.status.idle_timeout</param>
                     <param>::sep::Status Idle</param>

--- a/src/leds.c
+++ b/src/leds.c
@@ -78,6 +78,8 @@ static const uint32_t colors[] = {
 
 #define BATTERY_COLOR 0x00909090
 #define DUTY_COLOR 0x00FFB030
+#define MOTOR_CURRENT_COLOR 0x00FF5090
+#define BATTERY_CURRENT_COLOR 0x0000FF80
 #define FOOTPAD_SENSOR_COLOR 0x0000C0FF
 #define RED_BAR_COLOR 0x00FF3828
 #define BATTERY10_BAR_COLOR 0x00FF5038
@@ -535,21 +537,32 @@ static void anim_confirm(Leds *leds, const LedStrip *strip, float time) {
 }
 
 static void status_animate(
-    Leds *leds, const LedStrip *strip, float current_time, float blend, float idle_blend
+    Leds *leds,
+    const LedStrip *strip,
+    const MotorData *motor,
+    float current_time,
+    float blend,
+    float idle_blend
 ) {
     if (fabsf(VESC_IF->mc_get_rpm()) > ERPM_MOVING_THRESHOLD) {
         leds->status_idle_time = current_time;
     }
 
-    float duty = 0;
+    float duty = 0.0f;
+    float motor_current = 0.0f;
+    float battery_current = 0.0f;
     if (leds->state.state == STATE_RUNNING && leds->state.mode != MODE_FLYWHEEL) {
-        duty = fminf(fabsf(VESC_IF->mc_get_duty_cycle_now() * 10.0f / 9.0f), 1.0f);
+        duty = clampf(motor->duty_cycle.value * 10.0f / 9.0f, 0.0f, 1.0f);
+        motor_current = clampf(motor->motor_current_saturation, 0.0f, 1.0f);
+        battery_current = clampf(motor->battery_current_saturation, 0.0f, 1.0f);
     }
 
-    if (duty > leds->duty_threshold) {
-        rate_limitf(&leds->status_duty_blend, 1.0f, SB_RATE);
-    } else if (duty < leds->duty_threshold - 0.1f) {  // 10 percent hysteresis
-        rate_limitf(&leds->status_duty_blend, 0.0f, SB_RATE);
+    float motor_utilization = fmaxf(duty, fmaxf(motor_current, battery_current));
+    // 10 percent hysteresis
+    if (motor_utilization > leds->motor_utilization_threshold) {
+        rate_limitf(&leds->status_utilization_blend, 1.0f, SB_RATE);
+    } else if (motor_utilization < leds->motor_utilization_threshold - 0.1f) {
+        rate_limitf(&leds->status_utilization_blend, 0.0f, SB_RATE);
     }
 
     if (idle_blend > 0.0f) {
@@ -567,16 +580,28 @@ static void status_animate(
 
     if (idle_blend < 1.0f) {
         const bool reverse = strip == &leds->front_strip;
-        if (leds->status_duty_blend < 1.0f) {
+        if (leds->status_utilization_blend < 1.0f) {
             const float battery = VESC_IF->mc_get_battery_level(NULL);
             anim_battery_bar(
                 leds, strip, battery, reverse, fminf(blend, 1.0f - idle_blend), current_time
             );
         }
 
-        if (leds->status_duty_blend > 0.0f) {
+        if (leds->status_utilization_blend > 0.0f) {
+            float max_sat = duty;
+            uint32_t max_color = DUTY_COLOR;
+
+            if (motor_current > max_sat) {
+                max_sat = motor_current;
+                max_color = MOTOR_CURRENT_COLOR;
+            }
+            if (battery_current > max_sat) {
+                max_sat = battery_current;
+                max_color = BATTERY_CURRENT_COLOR;
+            }
+
             anim_progress_bar(
-                leds, strip, duty, DUTY_COLOR, true, reverse, leds->status_duty_blend
+                leds, strip, max_sat, max_color, true, reverse, leds->status_utilization_blend
             );
         }
 
@@ -770,8 +795,8 @@ void leds_init(Leds *leds) {
 
     leds->on_off_fade = 0.0f;
 
-    leds->duty_threshold = 0.0f;
-    leds->status_duty_blend = 0.0f;
+    leds->motor_utilization_threshold = 0.0f;
+    leds->status_utilization_blend = 0.0f;
     leds->status_idle_blend = 0.0f;
     leds->status_idle_time = 0.0f;
     leds->status_animation_start = 0.0f;
@@ -886,7 +911,7 @@ void leds_setup(Leds *leds, CfgHwLeds *hw_cfg, const CfgLeds *cfg) {
 }
 
 void leds_configure(Leds *leds, const CfgLeds *cfg) {
-    leds->duty_threshold = fmaxf(cfg->status.duty_threshold, 0.15);
+    leds->motor_utilization_threshold = fmaxf(cfg->status.motor_utilization_threshold, 0.15);
 
     leds->headlights_trans.transition = cfg->headlights_transition;
     leds->dir_trans.transition = cfg->direction_transition;
@@ -917,7 +942,9 @@ void leds_set_headlights_enabled(Leds *leds, bool value) {
     leds->runtime_status_overriden.headlights_enabled = true;
 }
 
-void leds_update(Leds *leds, const State *state, FootpadSensorState fs_state) {
+void leds_update(
+    Leds *leds, const State *state, const MotorData *motor, FootpadSensorState fs_state
+) {
     if (!leds->led_data) {
         return;
     }
@@ -1200,10 +1227,13 @@ void leds_update(Leds *leds, const State *state, FootpadSensorState fs_state) {
             rate_limitf(&leds->status_idle_blend, 0.0f, BR_RATE);
         }
 
-        status_animate(leds, &leds->status_strip, current_time, 1.0f, leds->status_idle_blend);
+        status_animate(
+            leds, &leds->status_strip, motor, current_time, 1.0f, leds->status_idle_blend
+        );
     }
 
-    if (leds->cfg->status_on_front_when_lifted && leds->status_on_front_blend > 0.0f) {
+    if (leds->cfg->status_on_front_when_lifted && leds->status_on_front_blend > 0.0f &&
+        leds->front_strip.length > 0) {
         if (leds->cfg->lights_off_when_lifted &&
             current_time - leds->status_on_front_idle_time > 3.0f) {
             rate_limitf(&leds->status_on_front_idle_blend, 1.0f, BR_RATE);
@@ -1214,6 +1244,7 @@ void leds_update(Leds *leds, const State *state, FootpadSensorState fs_state) {
         status_animate(
             leds,
             &leds->front_strip,
+            motor,
             current_time,
             leds->status_on_front_blend,
             leds->status_on_front_idle_blend

--- a/src/leds.h
+++ b/src/leds.h
@@ -21,6 +21,7 @@
 #include "footpad_sensor.h"
 #include "led_driver.h"
 #include "led_strip.h"
+#include "motor_data.h"
 #include "state.h"
 
 #define LEDS_REFRESH_RATE 30
@@ -51,8 +52,8 @@ typedef struct {
 
     float on_off_fade;
 
-    float duty_threshold;
-    float status_duty_blend;
+    float motor_utilization_threshold;
+    float status_utilization_blend;
     float status_idle_blend;
     float status_idle_time;
     float status_animation_start;
@@ -101,7 +102,9 @@ void leds_set_enabled(Leds *leds, bool value);
 
 void leds_set_headlights_enabled(Leds *leds, bool value);
 
-void leds_update(Leds *leds, const State *state, FootpadSensorState fs_state);
+void leds_update(
+    Leds *leds, const State *state, const MotorData *motor, FootpadSensorState fs_state
+);
 
 void leds_status_confirm(Leds *leds);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1154,7 +1154,7 @@ static void aux_thd(void *arg) {
             &d->imu_freq_tracker, running, &d->time, &imu_freq_update_reconfigure
         );
 
-        leds_update(&d->leds, &d->state, d->footpad.state);
+        leds_update(&d->leds, &d->state, &d->motor, d->footpad.state);
 
         // store odometer if we've gone more than 200m
         if (!running && VESC_IF->mc_get_odometer() > d->odometer + 200) {

--- a/src/motor_data.c
+++ b/src/motor_data.c
@@ -45,6 +45,8 @@ void motor_data_init(MotorData *m) {
 
     ema_init(&m->batt_current);
     m->batt_voltage = 0.0f;
+    m->motor_current_saturation = 0.0f;
+    m->battery_current_saturation = 0.0f;
 
     m->mosfet_temp = 0.0f;
     m->motor_temp = 0.0f;
@@ -89,7 +91,7 @@ void motor_data_refresh_motor_config(MotorData *m, float lv_threshold, float hv_
     // min motor current is a positive value here!
     m->current_min = fabsf(VESC_IF->get_cfg_float(CFG_PARAM_l_current_min));
     m->current_max = VESC_IF->get_cfg_float(CFG_PARAM_l_current_max);
-    m->battery_current_min = VESC_IF->get_cfg_float(CFG_PARAM_l_in_current_min);
+    m->battery_current_min = fabsf(VESC_IF->get_cfg_float(CFG_PARAM_l_in_current_min));
     m->battery_current_max = VESC_IF->get_cfg_float(CFG_PARAM_l_in_current_max);
     m->mosfet_temp_max = VESC_IF->get_cfg_float(CFG_PARAM_l_temp_fet_start) - 3;
     m->motor_temp_max = VESC_IF->get_cfg_float(CFG_PARAM_l_temp_motor_start) - 3;
@@ -144,6 +146,21 @@ void motor_data_update(MotorData *m, float dt) {
     ema_update(&m->batt_current, VESC_IF->mc_get_tot_current_in_filtered());
     m->batt_voltage = VESC_IF->mc_get_input_voltage_filtered();
 
+    float motor_current_limit = m->braking ? m->current_min : m->current_max;
+    if (motor_current_limit > 0.0f) {
+        m->motor_current_saturation = fabsf(m->filt_current.value) / motor_current_limit;
+    } else {
+        m->motor_current_saturation = 0.0f;
+    }
+
+    float battery_current_limit =
+        m->batt_current.value < 0 ? m->battery_current_min : m->battery_current_max;
+    if (battery_current_limit > 0.0f) {
+        m->battery_current_saturation = fabsf(m->batt_current.value) / battery_current_limit;
+    } else {
+        m->battery_current_saturation = 0.0f;
+    }
+
     m->mosfet_temp = VESC_IF->mc_temp_fet_filtered();
     m->motor_temp = VESC_IF->mc_temp_motor_filtered();
 }
@@ -158,10 +175,5 @@ void motor_data_evaluate_alerts(const MotorData *m, AlertTracker *at, const Time
 }
 
 float motor_data_get_current_saturation(const MotorData *m) {
-    float motor_saturation =
-        fabsf(m->filt_current.value) / (m->braking ? m->current_min : m->current_max);
-    float battery_saturation = m->batt_current.value /
-        (m->batt_current.value < 0 ? m->battery_current_min : m->battery_current_max);
-
-    return max(motor_saturation, battery_saturation);
+    return max(m->motor_current_saturation, m->battery_current_saturation);
 }

--- a/src/motor_data.h
+++ b/src/motor_data.h
@@ -50,6 +50,8 @@ typedef struct {
 
     EMA batt_current;
     float batt_voltage;
+    float motor_current_saturation;
+    float battery_current_saturation;
 
     float mosfet_temp;
     float motor_temp;

--- a/ui.qml.in
+++ b/ui.qml.in
@@ -1360,6 +1360,13 @@ Item {
             return tunes;
         }
 
+        function replaceProperty(tune, oldName, newName) {
+            if (tune.settings.hasOwnProperty(oldName)) {
+                tune.settings[newName] = tune.settings[oldName];
+                delete tune.settings[oldName];
+            }
+        }
+
         // Major package versions require a migration, minor don't.
         // Migration functions should return: [tuneObject, [newMajor, newMinor]]
         property var migrations: {
@@ -1375,6 +1382,11 @@ Item {
                 }
 
                 return [tune, [1, 2]];
+            },
+            "1.2": function(tune) {
+                replaceProperty(tune, "leds.status.duty_threshold", "leds.status.motor_utilization_threshold");
+
+                return [tune, [1, 3]];
             },
         }
 


### PR DESCRIPTION
Following up on this suggestion here: https://github.com/lukash/refloat/pull/44#issuecomment-2866685440

A couple things to align on before this is ready to merge:
- [x] right now DUTY = orange, MOTOR I = magenta, BATTERY I = green - let me know what you'd prefer
- [x] currently when the battery is low the last LED pulses every second - do we want this faster/slower?
- [x] ~~should I split out the battery blinking into a separate commit + `feature:` / leave it as is / update the current commit message + trailer?~~ done in https://github.com/lukash/refloat/pull/84
- [x] ~~I renamed `status_duty_blend -> status_blend`, and also `duty_threshold -> status_threshold`, hope that's alright~~ renamed to `status.motor_utilization_threshold`