### PR TITLE
Updated RT-TUNE and TUNE-OTHER commands (v1.3)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1722,6 +1722,9 @@ static void cmd_runtime_tune_tilt(Data *d, unsigned char *cfg, int len) {
     d->float_conf.tiltback_duty = (float) cfg[2] / 100.0;
     d->float_conf.tiltback_duty_angle = (float) cfg[3] / 10.0;
     d->float_conf.tiltback_duty_speed = (float) cfg[4] / 10.0;
+    if (len >= 6) {
+        d->float_conf.tiltback_speed = (float) cfg[5];
+    }
 
     beep_alert(d, 3, 0);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1576,8 +1576,12 @@ static void cmd_runtime_tune(Data *d, unsigned char *cfg, int len) {
 
         split(cfg[7], &h1, &h2);
         d->float_conf.atr_angle_limit = h1 + 5;
-        d->float_conf.atr_on_speed = (h2 & 0x3) + 3;
-        d->float_conf.atr_off_speed = (h2 >> 2) + 2;
+        if (h2 > 0) {
+            // kept for compatibility reasons
+            // wider ranges can be set with byte[18]
+            d->float_conf.atr_on_speed = (h2 & 0x3) + 3;
+            d->float_conf.atr_off_speed = (h2 >> 2) + 2;
+        }
 
         split(cfg[8], &h1, &h2);
         d->float_conf.atr_response_boost = ((float) h1) / 10 + 1;
@@ -1614,7 +1618,12 @@ static void cmd_runtime_tune(Data *d, unsigned char *cfg, int len) {
         split(cfg[15], &h1, &h2);
         float onspd = h1;
         float offspd = h2;
-        d->float_conf.torquetilt_on_speed = onspd / 2;
+        if (len >= 19) {
+            // use message length to identify apps that support the newer protocol
+            d->float_conf.torquetilt_on_speed = onspd + 3;
+        } else {
+            d->float_conf.torquetilt_on_speed = onspd / 2;
+        }
         d->float_conf.torquetilt_off_speed = offspd + 3;
     }
     if (len >= 17) {
@@ -1622,6 +1631,20 @@ static void cmd_runtime_tune(Data *d, unsigned char *cfg, int len) {
         d->float_conf.kp_brake = ((float) h1 + 1) / 10;
         d->float_conf.kp2_brake = ((float) h2) / 10;
         beep_alert(d, 1, 1);
+    }
+    if (len >= 19) {
+        split(cfg[17], &h1, &h2);
+        if (h1 > 0) {
+            d->float_conf.mahony_kp_roll = ((float) h1) / 10 + 1.0;
+        }
+        if (h2 > 0) {
+            d->float_conf.turntilt_start_angle = h2;
+        }
+        split(cfg[18], &h1, &h2);
+        if ((h1 > 0) && (h2 > 0)) {
+            d->float_conf.atr_on_speed = h1 * 2;
+            d->float_conf.atr_off_speed = h2 * 2;
+        }
     }
 
     reconfigure(d);

--- a/src/main.c
+++ b/src/main.c
@@ -1770,7 +1770,12 @@ static void cmd_runtime_tune_other(Data *d, unsigned char *cfg, int len) {
             d->float_conf.noseangling_speed = tiltspeed / 10;
         }
         d->float_conf.tiltback_variable = tiltvarrate / 100;
-        d->float_conf.tiltback_variable_max = tiltvarmax / 10;
+        if (tiltvarmax > 100) {
+            // numbers above 100 are negative
+            d->float_conf.tiltback_variable_max = (tiltvarmax - 100) / (-10);
+        } else {
+            d->float_conf.tiltback_variable_max = tiltvarmax / 10;
+        }
         d->float_conf.tiltback_variable_erpm = cfg[11] * 100;
     }
 
@@ -1783,6 +1788,17 @@ static void cmd_runtime_tune_other(Data *d, unsigned char *cfg, int len) {
                 d->float_conf.inputtilt_speed = cfg[13];
             }
         }
+    }
+
+    if (len >= 15) {
+        int flags2 = cfg[14];
+        // bits 0 & 1:
+        d->float_conf.fault_moving_fault_disabled = ((flags2 & 0x1) == 0x1);
+        d->float_conf.is_footbeep_enabled = ((flags2 & 0x2) == 0x2);
+        d->switch_warn_beep_erpm = d->float_conf.is_footbeep_enabled ? 2000 : 100000;
+        // bits 2 & 3:
+        int pbmode = (flags2 >> 2) & 0x3;
+        d->float_conf.parking_brake_mode = pbmode;
     }
 
     reconfigure(d);


### PR DESCRIPTION
This will allow features like negative variable tiltback as well as disable moving faults to be set via COMMAND_TUNE_OTHER. It also has some extensions to COMMAND_RT_TUNE (see individual commits)