### PR TITLE
Validate command headers before dispatch

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2393,13 +2393,13 @@ static void cmd_info(const Data *d, unsigned char *buf, int len) {
 // Handler for incoming app commands
 static void on_command_received(unsigned char *buffer, unsigned int len) {
     Data *d = (Data *) ARG;
-    uint8_t magicnr = buffer[0];
-    uint8_t command = buffer[1];
-
     if (len < 2) {
         log_error("Received command data too short.");
         return;
     }
+
+    uint8_t magicnr = buffer[0];
+    uint8_t command = buffer[1];
     if (magicnr != 101) {
         log_error("Invalid Package ID: %u", magicnr);
         return;

--- a/src/main.c
+++ b/src/main.c
@@ -2394,14 +2394,14 @@ static void cmd_info(const Data *d, unsigned char *buf, int len) {
 static void on_command_received(unsigned char *buffer, unsigned int len) {
     Data *d = (Data *) ARG;
     if (len < 2) {
-        log_error("Received command data too short.");
+        log_error("Received command data too short: %u bytes.", len);
         return;
     }
 
     uint8_t magicnr = buffer[0];
     uint8_t command = buffer[1];
     if (magicnr != 101) {
-        log_error("Invalid Package ID: %u", magicnr);
+        log_error("Invalid Package ID: %u", (unsigned) magicnr);
         return;
     }
 


### PR DESCRIPTION
Reject truncated app-command payloads before reading their two-byte header.

The VESC app-data callback can receive zero- or one-byte payloads. The old handler read `buffer[0]` and `buffer[1]` before checking the length, producing an out-of-bounds read. The old length check then returned for `len < 2`, so these packets did not reach command dispatch.

The guard now runs before either header byte is accessed.

I was able to eventually get a device reboot from this but it took a lot of packets.