### PR TITLE
Pass Konami sequence element counts

### DIFF
--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -38,6 +38,7 @@
 #define TORQUE_CONSTANT_COMPAT (1.5f * 15 * 0.027f)
 
 #define unused(x) (void) (x)
+#define array_size(array) (sizeof(array) / sizeof((array)[0]))
 
 #if defined(__GNUC__) && __GNUC__ < 9
 

--- a/src/main.c
+++ b/src/main.c
@@ -1216,16 +1216,18 @@ static void data_init(Data *d) {
 
     data_recorder_init(&d->data_record, imu_sample_rate);
 
-    konami_init(&d->flywheel_konami, flywheel_konami_sequence, sizeof(flywheel_konami_sequence));
+    konami_init(
+        &d->flywheel_konami, flywheel_konami_sequence, array_size(flywheel_konami_sequence)
+    );
     konami_init(
         &d->headlights_on_konami,
         headlights_on_konami_sequence,
-        sizeof(headlights_on_konami_sequence)
+        array_size(headlights_on_konami_sequence)
     );
     konami_init(
         &d->headlights_off_konami,
         headlights_off_konami_sequence,
-        sizeof(headlights_off_konami_sequence)
+        array_size(headlights_off_konami_sequence)
     );
 
     ema_init(&d->balance_current);


### PR DESCRIPTION
Passes element counts, rather than byte sizes, when initializing the three footpad gesture sequences.

## Why

`konami_init` expects a `uint8_t` element count. The old code passed `sizeof(sequence)`, which is the array byte size. After a valid gesture was consumed, the state machine could therefore continue indexing past the end of the sequence.

## Changes

- Pass the element count for the flywheel, headlights-on, and headlights-off sequences.
- Convert each derived count explicitly at the `uint8_t` API boundary.
- Assert at compile time that every fixed sequence fits that representation.

## Scope

Only initialization of the three fixed gestures changes. Their contents, timing, and valid state-machine behavior are otherwise unchanged.

Hilariously, it seems possible to do a TAS-style physical reproduction of this but there is no way I am going to spend the time to try. I did get strange behavior after enough trying to trigger it manually though.