### PR TITLE
Preserve circular buffer item semantics

### DIFF
--- a/src/lib/circular_buffer.c
+++ b/src/lib/circular_buffer.c
@@ -96,7 +96,7 @@ void circular_buffer_iterate(
 
     size_t i = cb->tail;
     do {
-        callback(&cb->buffer[i], data);
+        callback(cb->buffer + i * cb->item_size, data);
         increment(cb, &i);
     } while (i != cb->head);
 }

--- a/src/lib/circular_buffer.c
+++ b/src/lib/circular_buffer.c
@@ -74,8 +74,8 @@ bool circular_buffer_get(const CircularBuffer *cb, size_t i, void *item) {
     return true;
 }
 
-bool circular_buffer_pop(CircularBuffer *cb, size_t i, void *item) {
-    if (!circular_buffer_get(cb, i, item)) {
+bool circular_buffer_pop(CircularBuffer *cb, void *item) {
+    if (!circular_buffer_get(cb, 0, item)) {
         return false;
     }
 

--- a/src/lib/circular_buffer.h
+++ b/src/lib/circular_buffer.h
@@ -53,11 +53,10 @@ void circular_buffer_push(CircularBuffer *cb, const void *item);
 bool circular_buffer_get(const CircularBuffer *cb, size_t i, void *item);
 
 /**
- * Pops an item at index i (a position relative to the current tail) from the
- * buffer. If there's no item at that index, leaves item unchanged and returns
- * false, otherwise returns true.
+ * Pops the item at the tail of the buffer. If the buffer is empty, leaves item
+ * unchanged and returns false, otherwise returns true.
  */
-bool circular_buffer_pop(CircularBuffer *cb, size_t i, void *item);
+bool circular_buffer_pop(CircularBuffer *cb, void *item);
 
 /**
  * Iterates over the buffer, calling the callback function on each item.


### PR DESCRIPTION
Fix two independent circular-buffer behaviors.

`circular_buffer_iterate()` previously used an item index as a byte offset. For buffers containing multi-byte records, callbacks after the first could therefore receive pointers inside another record. The index is now multiplied by `item_size` so each callback receives a complete item. This fixes the experimental recorder plotting path, which iterates over `Sample` records.

Following review feedback, `circular_buffer_pop()` now implements a conventional FIFO pop: its unused index argument was removed, it copies the item at the tail, and then advances the tail. There are currently no callers requiring migration.

The defensive argument guards and indexed-item shifting from earlier revisions were removed following review feedback.