### PR TITLE
Plot decoded recorder samples in seconds

### DIFF
--- a/src/conf/buffer.c
+++ b/src/conf/buffer.c
@@ -40,6 +40,14 @@ uint16_t to_float16(float x) {
     return (b&0x80000000)>>16 | (e>112)*((((e-112)<<10)&0x7C00)|m>>13) | ((e<113)&(e>101))*((((0x007FF000+m)>>(125-e))+1)>>1) | (e>143)*0x7FFF;
 }
 
+float from_float16(uint16_t x) {
+    const float sign = x & 0x8000u ? -1.0f : 1.0f;
+    const uint16_t exponent = (x >> 10) & 0x1fu;
+    const uint16_t mantissa = x & 0x03ffu;
+    return sign * (exponent ? ldexpf(1024.0f + mantissa, exponent - 25)
+                            : ldexpf(mantissa, -24));
+}
+
 // clang-format on
 #pragma GCC diagnostic pop
 

--- a/src/conf/buffer.h
+++ b/src/conf/buffer.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 uint16_t to_float16(float x);
+float from_float16(uint16_t x);
 
 void buffer_append_int16(uint8_t *buffer, int16_t number, int32_t *index);
 void buffer_append_uint16(uint8_t *buffer, uint16_t number, int32_t *index);

--- a/src/data_recorder.c
+++ b/src/data_recorder.c
@@ -134,11 +134,10 @@ static void send_point_vt_experiment(const void *item, void *data) {
     unused(data);
 
     Sample *sample = (Sample *) item;
+    const float time = sample->time * (1.0f / SYSTEM_TICK_RATE_HZ);
     for (uint8_t i = 0; i < ITEMS_COUNT_REC(RT_DATA_ALL_ITEMS); ++i) {
         VESC_IF->plot_set_graph(i);
-        VESC_IF->plot_send_points(
-            sample->time * (1.0f / SYSTEM_TICK_RATE_HZ), from_float16(sample->values[i])
-        );
+        VESC_IF->plot_send_points(time, from_float16(sample->values[i]));
     }
 }
 

--- a/src/data_recorder.c
+++ b/src/data_recorder.c
@@ -136,7 +136,9 @@ static void send_point_vt_experiment(const void *item, void *data) {
     Sample *sample = (Sample *) item;
     for (uint8_t i = 0; i < ITEMS_COUNT_REC(RT_DATA_ALL_ITEMS); ++i) {
         VESC_IF->plot_set_graph(i);
-        VESC_IF->plot_send_points(sample->time, sample->values[i]);
+        VESC_IF->plot_send_points(
+            sample->time * (1.0f / SYSTEM_TICK_RATE_HZ), from_float16(sample->values[i])
+        );
     }
 }
 

--- a/src/data_recorder.c
+++ b/src/data_recorder.c
@@ -131,10 +131,10 @@ void data_recorder_sample(DataRecord *dr, const Data *d, time_t time) {
 }
 
 static void send_point_vt_experiment(const void *item, void *data) {
-    unused(data);
+    const time_t start_time = *(const time_t *) data;
 
-    Sample *sample = (Sample *) item;
-    const float time = sample->time * (1.0f / SYSTEM_TICK_RATE_HZ);
+    const Sample *sample = (const Sample *) item;
+    const float time = (sample->time - start_time) * (1.0f / SYSTEM_TICK_RATE_HZ);
     for (uint8_t i = 0; i < ITEMS_COUNT_REC(RT_DATA_ALL_ITEMS); ++i) {
         VESC_IF->plot_set_graph(i);
         VESC_IF->plot_send_points(time, from_float16(sample->values[i]));
@@ -152,7 +152,9 @@ void data_recorder_send_experiment_plot(DataRecord *dr) {
     VISIT_REC(RT_DATA_ALL_ITEMS, ADD_GRAPH);
 #undef ADD_GRAPH
 
-    circular_buffer_iterate(&dr->buffer, &send_point_vt_experiment, 0);
+    Sample first_sample = {0};
+    circular_buffer_get(&dr->buffer, 0, &first_sample);
+    circular_buffer_iterate(&dr->buffer, &send_point_vt_experiment, &first_sample.time);
 }
 
 typedef enum {


### PR DESCRIPTION
Decode stored half-precision recorder values before plotting and convert tick timestamps to seconds on the x-axis.

Recorder storage and binary data responses are unchanged.
